### PR TITLE
Correct code blocks and additional clarification for RemoteEvents and NetworkEvents

### DIFF
--- a/docs/classes/NetworkEvent/Functions/InvokeClient.md
+++ b/docs/classes/NetworkEvent/Functions/InvokeClient.md
@@ -15,5 +15,5 @@ player `Player`
 ```lua
 local message = NetMessage.New()
 message.AddString("key", "value")
-netEvent.InvokeClient(msg, game["Players"]["willemsteller"])
+netEvent.InvokeClient(message, game["Players"]["willemsteller"])
 ```

--- a/docs/classes/NetworkEvent/Functions/InvokeClients.md
+++ b/docs/classes/NetworkEvent/Functions/InvokeClients.md
@@ -14,5 +14,5 @@ msg `NetMessage`
 ```lua
 local message = NetMessage.New()
 message.AddString("key", "value")
-netEvent.InvokeClients(msg)
+netEvent.InvokeClients(message)
 ```

--- a/docs/classes/NetworkEvent/Functions/InvokeServer.md
+++ b/docs/classes/NetworkEvent/Functions/InvokeServer.md
@@ -15,5 +15,5 @@ player `Player`
 ```lua
 local message = NetMessage.New()
 message.AddString("key", "value")
-netEvent.InvokeServer(msg)
+netEvent.InvokeServer(message)
 ```

--- a/docs/classes/RemoteEvent/Events/Invoked.md
+++ b/docs/classes/RemoteEvent/Events/Invoked.md
@@ -5,11 +5,12 @@ Fires when the Invoke function is called.
 Event of [RemoteEvent](/classes/RemoteEvent/)
 
 #### Returns
+Parameter `Player`
 Parameter `object`
 
 ### Example
 ```lua
-event.Invoked:Connect(function(par)
-    print(par)
+event.Invoked:Connect(function(player, value)
+    print("Received value "..value.." from "..player.Name)
 end)
 ```

--- a/docs/classes/RemoteEvent/Functions/Invoke.md
+++ b/docs/classes/RemoteEvent/Functions/Invoke.md
@@ -1,6 +1,6 @@
 # Invoke
 ### Description
-Invokes the event.
+Invokes the event. Can only be called from client.
 
 Function of [RemoteEvent](/classes/RemoteEvent/)
 


### PR DESCRIPTION
This pull request fixes several typos in the code block examples in RemoteEvents and NetworkEvents. In addition, it also makes a correction in Invoked that more accurately reflects the actual behavior, considering that Invoked has a player parameter that for some reason is omitted in the wiki entry.

I also added a clarification for Invoke that it should only be called from the client. Had to learn this the hard way.