### PR TITLE
Update MoveTarget Misinfo

### DIFF
--- a/docs/classes/NPC/Properties/MoveTarget.md
+++ b/docs/classes/NPC/Properties/MoveTarget.md
@@ -8,10 +8,10 @@ Property of [NPC](/classes/NPC/)
 
 #### Type
 
-`Vector3`
+`Instance`
 
 ### Example
 
 ```lua
-npc.MoveTarget = Vector3.New(100, 0, 0)
+npc.MoveTarget = game["Environment"]["Part"]
 ```


### PR DESCRIPTION
MoveTarget seems to give misinformation. In the documentation, it says that it requires Vector3, but in the client, it needs the instance instead. This pull request fixes that.

![image](https://github.com/Polytoria/Docs/assets/60780448/8811ae3d-d339-4212-98c1-2e202aa2b35b)
_wrongly documented npc_