### PR TITLE
Update SetParent.md

### DIFF
--- a/docs/classes/Instance/Functions/SetParent.md
+++ b/docs/classes/Instance/Functions/SetParent.md
@@ -2,7 +2,7 @@
 
 ### Description
 
-Returns the parent of this instance.
+Sets the parent of this instance.
 
 Function of [Instance](/classes/Instance/)
 


### PR DESCRIPTION
Change "Returns" to "Sets"

Up for discussion: whether or not it should say "this instance" (current) or "an instance".

This is a duplicate pull request so I can just suggest to change "Returns" to "Sets" and does not include my belief that it should say "an instance" instead of "this instance".