### PR TITLE
Document RemoteEvent (Removed)

### DIFF
--- a/docs/removed/RemoteEvent.md
+++ b/docs/removed/RemoteEvent.md
@@ -1,6 +1,6 @@
 ---
 title: RemoteEvent
-description: RemoteEvents were the old NetworkEvents. They have since been replaced with NetworkEvents and have been removed.
+description: RemoteEvents was events that can be called by clients to send data to the server.
 icon: polytoria/NetworkEvent
 ---
 
@@ -8,9 +8,42 @@ icon: polytoria/NetworkEvent
 
 <div data-search-exclude markdown>
 !!! danger "Removed"
-    The RemoteEvent class was removed in Version [TO-DO, not sure what version], and is currently noted for documentation purposes. It is not recommended, if possible, to use in recent versions.
+    The RemoteEvent class was removed in a previous version of Polytoria, and is currently noted for documentation purposes.
+    
 </div>
 
-RemoteEvents was a class used similarly to {{ classLink("NetworkEvent") }}s.
+RemoteEvents was events that could be called by clients to send data to the server.
 
-TO-DO REST OF THE DOCUMENTATION
+<div data-search-exclude markdown>
+!!! note "RemoteEvents only supported one parameter due to networking limitations."
+</div>
+
+## Events
+
+### Invoked:Player { event }
+
+Fires when the Invoke function is called.
+
+<div data-search-exclude markdown>
+!!! tip "This event had the ability to return paramaters `Player` or `object`"
+</div>
+
+**Example**
+
+```lua
+event.Invoked:Connect(function(player, value)
+    print("Received value "..value.." from "..player.Name)
+end)
+```
+
+## Methods
+
+### Invoke(object) { method }
+
+Invokes the event. Can only be called from client.
+
+**Example**
+
+```lua
+event.Invoke(Vector3.New(0, 100, 0))
+```

--- a/docs/removed/UI.md
+++ b/docs/removed/UI.md
@@ -8,7 +8,7 @@ icon: polytoria/UI
 
 <div data-search-exclude markdown>
 !!! danger "Removed"
-    The UI static class was removed in Version 1.2.0, and is currently noted for documentation purposes. It is not recommended, if possible, to use in recent versions.
+    The UI static class was removed in Version 1.2.0, and is currently noted for documentation purposes.
 </div>
 
 {{ staticclass("UI")}}


### PR DESCRIPTION
I documented RemoteEvent, even though it currently no longer exists. It is located in the removed classes section.