### PR TITLE
Add Event documentation

### DIFF
--- a/docs/objects/types/Event.md
+++ b/docs/objects/types/Event.md
@@ -1,0 +1,58 @@
+---
+title: Event
+description: Event is the data type that represents listenable events.
+icon: polytoria/Event
+---
+
+# Event
+
+Event is a data type that represents listenable events.
+
+You aren't able to create your own listenable events using this data type.
+
+Events are present on many different objects and are marked with :polytoria-Event: on the Documentation.
+
+## Methods
+
+### Connect(function) { method }
+
+Connect the specified function to the event. When the event is fired, the function will be ran. The event parameters may be passed to the function, if there are any.
+
+**Example**
+
+The function may be specified in 2 different ways:
+
+```lua
+function hitListener(hit)
+    print(hit.Name .. "touched the Part!")
+end
+
+game["Environment"]["Part"].Touched:Connect(hitListener)
+```
+
+and
+
+```lua
+game["Environment"]["Part"].Touched:Connect(function(hit)
+    print(hit.Name .. "touched the Part!")
+end)
+```
+
+**Note: Defining a function within the Connect method will cause the function to be non-removable from the event.**
+
+### Disconnect(function) { method }
+
+Disconnect the specified function from the event.
+
+**Example**
+
+```lua
+function hitListener(hit)
+    print(hit.Name .. "touched the Part!")
+end
+
+game["Environment"]["Part"].Touched:Connect(hitListener)
+wait(5)
+-- hitListener(hit) will no longer run when the event is fired after the following line
+game["Environment"]["Part"].Touched:Disconnect(hitListener)
+```

--- a/main.py
+++ b/main.py
@@ -253,7 +253,7 @@ def event(name):
         elif len(parameters) == 1:
             parametersList = f"\n!!! quote \"**Parameters:** <span style=\"font-weight: normal;\">" + parameters[0] + "</span>\""
 
-    return "### :polytoria-Event: %s { #%s data-toc-label=\"%s\" }%s" % (name, name, name, parametersList)
+    return "### <a href=\"/objects/types/Event/\">:polytoria-Event:</a> %s { #%s data-toc-label=\"%s\" }%s" % (name, name, name, parametersList)
 
 def method(name):
     value = name[3:] # in form "name:type"


### PR DESCRIPTION
Adds a page documentating the event data type (?, not sure if it's a data type, it doesn't seem to be a class to me either) and makes the event icon redirect to that page for easier access
