### PR TITLE
Correct Http Ratelimit

### DIFF
--- a/docs/objects/static-classes/Http.md
+++ b/docs/objects/static-classes/Http.md
@@ -13,7 +13,7 @@ icon: polytoria/Http
 {{ serverexclusive() }}
 
 <div data-search-exclude markdown>
-!!! warning "Each server has a rate limit of 15 requests per minute."
+!!! warning "Each server has a rate limit of 90 requests per minute."
 
 !!! note "The place ID is sent along with the request under the header named `PT-Game-ID`."
 


### PR DESCRIPTION
## PR Summary

I did a short test, since the 15 req/min limit seemed extremely low, and unsurprisingly it seems to be off. The actual limit I was able to reproduce was 90 requests/minute.

https://polytoria.com/places/8802 <- This is what I used for testing, it sends a request every 0.1 seconds and resets the counter if one of them fails, and after 90 it fails due to the limits.

Thanks for taking the time to contribute to the Polytoria documentation project!
Please ensure that this PR meets the following criteria before submitting (you may delete this section after reading):

- [x] The changes you've made are accurate and correct
- [x] Distinct changes for separate issues are in separate PRs (do not combine multiple issues into one PR)
- [x] Any additions or modifications to the example code were tested in the latest version of Polytoria Creator and work as intended
