### PR TITLE
Make the distinction of floats and integers visible

### DIFF
--- a/docs/objects/effects/PointLight.md
+++ b/docs/objects/effects/PointLight.md
@@ -12,7 +12,7 @@ icon: polytoria/PointLight
 
 ## Properties
 
-### Brightness:int { property }
+### Brightness:float { property }
 
 Specifies how bright/intense the light is.
 
@@ -32,7 +32,7 @@ Specifies the color of the light.
 light.Color = Color.Random()
 ```
 
-### Range:int { property }
+### Range:float { property }
 
 Specifies how far out the light can reach.
 

--- a/docs/objects/effects/Sound.md
+++ b/docs/objects/effects/Sound.md
@@ -41,7 +41,7 @@ Stops playing the sound.
 
 Determines whether the sound should start playing automatically.
 
-### Length:int { property }
+### Length:float { property }
 
 Returns the length of the currently loaded audio
 
@@ -49,7 +49,7 @@ Returns the length of the currently loaded audio
 
 Determines whether the sound should loop or not.
 
-### Pitch:int { property }
+### Pitch:float { property }
 
 The pitch of the sound.
 
@@ -57,7 +57,7 @@ The pitch of the sound.
 
 When enabled, the sound will be played in 3D world space rather than having the same volume for everyone.
 
-### MaxDistance:int { property }
+### MaxDistance:float { property }
 
 Specifies how far the player must be from the sound for it to stop playing, if the `PlayInWorld` property is set to true.
 
@@ -73,10 +73,10 @@ The size of the sound.
 
 The asset ID of the sound.
 
-### Time:int { property }
+### Time:float { property }
 
 The time position the track is currently on.
 
-### Volume:int { property }
+### Volume:float { property }
 
 The volume of the sound.

--- a/docs/objects/effects/SpotLight.md
+++ b/docs/objects/effects/SpotLight.md
@@ -12,11 +12,11 @@ icon: polytoria/SpotLight
 
 ## Properties
 
-### Angle:int { property }
+### Angle:float { property }
 
 Specifies the angle of the spotlight.
 
-### Brightness:int { property }
+### Brightness:float { property }
 
 Specifies how bright/intense the light is.
 
@@ -28,7 +28,7 @@ Specifies how bright/intense the light is.
 
 Specifies the color of the light.
 
-### Range:int { property }
+### Range:float { property }
 
 Specifies how far out the light can reach.
 

--- a/docs/objects/game/Environment.md
+++ b/docs/objects/game/Environment.md
@@ -17,7 +17,7 @@ weight: 2
 
 ## Methods
 
-### CreateExplosion(Position;Vector3,Radius;int=10,Force;int=5000,affectAnchored;bool=true,callback;function=nil,damage;int=10000) { method }
+### CreateExplosion(Position;Vector3,Radius;float=10,Force;float=5000,affectAnchored;bool=true,callback;function=nil,damage;float=10000) { method }
 
 Creates a deadly explosion killing players and applying force to parts at the given position.
 
@@ -35,7 +35,7 @@ game["Environment"]:CreateExplosion(Vector3.New(0, 0, 0), 30, 5000, false, nil, 
 !!! note "Callback gets called for each part within explosion radius."
 </div>
 
-### Raycast(origin;Vector3,direction;Vector3,maxDistance;int=infinite,ignoreList;array=Instance[]):RayResult { method }
+### Raycast(origin;Vector3,direction;Vector3,maxDistance;float=infinite,ignoreList;array=Instance[]):RayResult { method }
 
 Casts a ray from origin with a specified direction and returns a RayResult for the first hit object.
 
@@ -49,7 +49,7 @@ if hit and hit.Instance:IsA("Player") then
 end
 ```
 
-### RaycastAll(origin;Vector3,direction;Vector3,maxDistance;int=infinite,ignoreList;array=Instance[]):RayResult { method }
+### RaycastAll(origin;Vector3,direction;Vector3,maxDistance;float=infinite,ignoreList;array=Instance[]):RayResult { method }
 
 Casts a ray from origin with a specified direction and returns a RayResult array for all hit objects.
 

--- a/docs/objects/game/Player.md
+++ b/docs/objects/game/Player.md
@@ -167,7 +167,7 @@ game["Players"]["willemsteller"].ChatColor = Color3.New(0, 1, 0)
 
 Specifies the color of the players's head.
 
-### Health:int=100 { property }
+### Health:float=100 { property }
 
 The current health of the player.
 
@@ -189,7 +189,7 @@ Determines whether or not the player is currently focused on an input.
 
 {{ readonly() }}
 
-### JumpPower:int=36 { property }
+### JumpPower:float=36 { property }
 
 Specifies how high the player's jump is.
 
@@ -201,15 +201,15 @@ Specifies the color of the players's left arm.
 
 Specifies the color of the players's left leg.
 
-### MaxHealth:int=100 { property }
+### MaxHealth:float=100 { property }
 
 Specifies the maximum health the player can have.
 
-### MaxStamina:int=3 { property }
+### MaxStamina:float=3 { property }
 
 Specifies the maximum stamina the player can have.
 
-### RespawnTime:int=5 { property }
+### RespawnTime:float=5 { property }
 
 Determines how long it takes between the player's death and respawn.
 
@@ -225,7 +225,7 @@ Specifies the color of the players's right leg.
 
 Returns the seat the player is currently sitting in, `nil` if the player is not sitting in any seat.
 
-### SprintSpeed:int=25 { property }
+### SprintSpeed:float=25 { property }
 
 Determines how fast the player is while sprinting.
 
@@ -236,7 +236,7 @@ Determines how fast the player is while sprinting.
 
 </div>
 
-### Stamina:int=0 { property }
+### Stamina:float=0 { property }
 
 The player's current amount of stamina.
 
@@ -244,7 +244,7 @@ The player's current amount of stamina.
 
 Determines whether or not stamina is enabled for the player.
 
-### StaminaRegen:int=1.2 { property }
+### StaminaRegen:float=1.2 { property }
 
 The rate at which stamina regenerates after being depleted for the player.
 
@@ -258,6 +258,6 @@ Returns the player's user ID.
 
 {{ readonly() }}
 
-### WalkSpeed:int=16 { property }
+### WalkSpeed:float=16 { property }
 
 Determines how fast the player walks.

--- a/docs/objects/game/PlayerDefaults.md
+++ b/docs/objects/game/PlayerDefaults.md
@@ -27,27 +27,27 @@ Resets the specified player back to their default values.
 
 Determines the default color of players' usernames in chat.
 
-### JumpPower:int=36 { property }
+### JumpPower:float=36 { property }
 
 Determines how high the player jumps by default.
 
-### MaxHealth:int=100 { property }
+### MaxHealth:float=100 { property }
 
 Determines the default maximum health of players.
 
-### MaxStamina:int=3 { property }
+### MaxStamina:float=3 { property }
 
 Determines the default maximum stamina of players.
 
-### RespawnTime:int=5 { property }
+### RespawnTime:float=5 { property }
 
 Determines the default of how long it takes between player's death and respawn.
 
-### SprintSpeed:int=25 { property }
+### SprintSpeed:float=25 { property }
 
 Determines the default sprint speed of players.
 
-### Stamina:int=0 { property }
+### Stamina:float=0 { property }
 
 Determines the default stamina of players.
 
@@ -55,10 +55,10 @@ Determines the default stamina of players.
 
 Determines whether or not stamina is enabled by default for players.
 
-### StaminaRegen:int=1.2 { property }
+### StaminaRegen:float=1.2 { property }
 
 Determines the default rate at which stamina regenerates after being depleted for players.
 
-### WalkSpeed:int=16 { property }
+### WalkSpeed:float=16 { property }
 
 Determines how fast the player walks by default.

--- a/docs/objects/physics/BodyPosition.md
+++ b/docs/objects/physics/BodyPosition.md
@@ -13,7 +13,7 @@ icon: polytoria/BodyPosition
 
 ## Properties
 
-### AcceptableDistance:int { property }
+### AcceptableDistance:float { property }
 
 Determines how close the body has to be to the target position to stop applying forces to it.
 
@@ -23,7 +23,7 @@ Determines how close the body has to be to the target position to stop applying 
 bodyPosition.AcceptanceDistance = 5
 ```
 
-### Force:int { property }
+### Force:float { property }
 
 Determines how much force the body applies.
 

--- a/docs/objects/static-classes/Achievements.md
+++ b/docs/objects/static-classes/Achievements.md
@@ -18,7 +18,7 @@ icon: polytoria/Achievements
 
 ## Methods
 
-### Award(playerUserID;number,achievementID;number,callback;function):callback { method }
+### Award(playerUserID;int,achievementID;int,callback;function):callback { method }
 
 Awards the specified player the specified achievement.
 
@@ -39,7 +39,7 @@ end)
 
 The callback function has the parameters "success", indicating if the award succeeded, and "error", which contains the error message if the award failed.
 
-### HasAchievement(playerUserID;number,achievementID;number,callback;function):callback { method }
+### HasAchievement(playerUserID;int,achievementID;int,callback;function):callback { method }
 
 Check if the specified player has the specified achievement.
 

--- a/docs/objects/static-classes/Camera.md
+++ b/docs/objects/static-classes/Camera.md
@@ -18,7 +18,7 @@ icon: polytoria/Camera
 
 ## Properties
 
-### Distance:int { property }
+### Distance:float { property }
 
 Determines the distance between the camera and the player when the camera is in `FollowPlayer` mode.
 
@@ -28,7 +28,7 @@ Determines the distance between the camera and the player when the camera is in 
 Camera.Distance = 20
 ```
 
-### FOV:int { property }
+### FOV:float { property }
 
 Determines or returns the camera's field of view.
 
@@ -38,7 +38,7 @@ Determines or returns the camera's field of view.
 Camera.FOV = 90
 ```
 
-### FastFlySpeed:int { property }
+### FastFlySpeed:float { property }
 
 Determines the camera speed when the camera is in `FreeCam` mode while holding shift.
 
@@ -48,7 +48,7 @@ Determines the camera speed when the camera is in `FreeCam` mode while holding s
 Camera.FastFlySpeed = 100
 ```
 
-### FlySpeed:int { property }
+### FlySpeed:float { property }
 
 Determines the camera speed when the camera is in `FreeCam` mode.
 
@@ -68,7 +68,7 @@ Determines whether or not to use lerping in `FollowPlayer` mode.
 Camera.FollowLerp = true
 ```
 
-### FreeLookSensitivity:int { property }
+### FreeLookSensitivity:float { property }
 
 Determines the mouse sensitivity while in `FreeCam` mode.
 
@@ -78,7 +78,7 @@ Determines the mouse sensitivity while in `FreeCam` mode.
 Camera.FreeLookSensitivity = 3
 ```
 
-### HorizontalSpeed:int { property }
+### HorizontalSpeed:float { property }
 
 Determines the horizontal movement speed of the camera in `FollowPlayer` mode.
 
@@ -100,7 +100,7 @@ print(Camera.IsFirstPerson)
 
 {{ readonly() }}
 
-### LerpSpeed:int { property }
+### LerpSpeed:float { property }
 
 Determines the lerp speed of the camera when lerping is enabled.
 
@@ -110,7 +110,7 @@ Determines the lerp speed of the camera when lerping is enabled.
 Camera.LerpSpeed = 15
 ```
 
-### MaxDistance:int { property }
+### MaxDistance:float { property }
 
 Determines camera's maximum distance from the player in `FollowPlayer` mode.
 
@@ -120,7 +120,7 @@ Determines camera's maximum distance from the player in `FollowPlayer` mode.
 Camera.MaxDistance = 0
 ```
 
-### MinDistance:int { property }
+### MinDistance:float { property }
 
 The camera's minimum distance from the player in FollowPlayer mode.
 
@@ -150,7 +150,7 @@ Determines whether or not the camera should render in orthographic (2D) mode or 
 Camera.Orthographic = true
 ```
 
-### OrthographicSize:int { property }
+### OrthographicSize:float { property }
 
 Determines the half-size of the camera when in orthographic mode.
 
@@ -180,7 +180,7 @@ Determines or returns rotation of the camera.
 Camera.Rotation = Vector3.New(90, 0, 0)
 ```
 
-### ScrollSensitivity:int { property }
+### ScrollSensitivity:float { property }
 
 Determines the scroll move speed of the camera.
 
@@ -190,7 +190,7 @@ Determines the scroll move speed of the camera.
 Camera.ScrollSensitivity = 15
 ```
 
-### VerticalSpeed:int { property }
+### VerticalSpeed:float { property }
 
 Determines the vertical move speed of the camera.
 

--- a/docs/objects/static-classes/Tween.md
+++ b/docs/objects/static-classes/Tween.md
@@ -20,7 +20,7 @@ icon: polytoria/Tween
 
 ## Methods
 
-### TweenColor(startValue;Color,endValue;Color,time;number,callPerStep;function,type;TweenType,callback;function):int { method }
+### TweenColor(startValue;Color,endValue;Color,time;float,callPerStep;function,type;TweenType,callback;function):int { method }
 
 Tweens a color between two specified values.
 
@@ -34,7 +34,7 @@ end, TweenType.linear, function()
 end
 ```
 
-### TweenNumber(startValue;int,endValue;int,time;number,callPerStep;function,type;TweenType,callback;function):int { method }
+### TweenNumber(startValue;float,endValue;float,time;float,callPerStep;function,type;TweenType,callback;function):int { method }
 
 Tweens a number between two specified values.
 
@@ -48,7 +48,7 @@ end, TweenType.linear, function()
 end)
 ```
 
-### TweenPosition(target;DynamicInstance,destination;Vector3,time;number,type;TweenType,callback;function):int { method }
+### TweenPosition(target;DynamicInstance,destination;Vector3,time;float,type;TweenType,callback;function):int { method }
 
 Tweens the position of a DynamicInstance
 
@@ -60,7 +60,7 @@ Tween:TweenPosition(part, Vector3.New(100, 0, 0), 100, TweenType.linear, functio
 end)
 ```
 
-### TweenRotation(target;DynamicInstance,destination;Vector3,time;number,type;TweenType,callback;function):int { method }
+### TweenRotation(target;DynamicInstance,destination;Vector3,time;float,type;TweenType,callback;function):int { method }
 
 Tweens the rotation of a DynamicInstance
 
@@ -76,7 +76,7 @@ Tween:TweenRotation(part, Vector3.New(0, 90, 0), 1, TweenType.linear, function()
 end)
 ```
 
-### TweenSize(target;DynamicInstance,endValue;Vector3,time;number,type;TweenType,callback;function):int { method }
+### TweenSize(target;DynamicInstance,endValue;Vector3,time;float,type;TweenType,callback;function):int { method }
 
 Tweens the size of a DynamicInstance
 
@@ -88,7 +88,7 @@ Tween:TweenSize(part, Vector3.New(5, 5, 5), 1, TweenType.linear, function()
 end)
 ```
 
-### TweenVector2(startValue;Vector2,endValue;Vector2,time;int,callPerStep;function,type;TweenType,callback;function):int { method }
+### TweenVector2(startValue;Vector2,endValue;Vector2,time;float,callPerStep;function,type;TweenType,callback;function):int { method }
 
 Tweens a vector2 between two specified values.
 
@@ -102,7 +102,7 @@ end, TweenType.linear, function()
 end)
 ```
 
-### TweenVector3(startValue;Vector3,endValue;Vector3,time;int,callPerStep;function,type;TweenType,callback;function):int { method }
+### TweenVector3(startValue;Vector3,endValue;Vector3,time;float,callPerStep;function,type;TweenType,callback;function):int { method }
 
 Tweens a vector3 between two specified values.
 

--- a/docs/objects/types/Color.md
+++ b/docs/objects/types/Color.md
@@ -17,9 +17,9 @@ The alpha property is between 0 and 255. 0 is fully transparent and 255 is fully
 | Name                                                      | Description                                                                |
 | --------------------------------------------------------- | -------------------------------------------------------------------------- |
 | Color.New()                                               | Creates a new black color.                                                 |
-| Color.New(`number` n)                                     | Creates a new Color with an R, G and B value of n.                         |
-| Color.New(`number` r, `number` g, `number` b)             | Creates a new Color with the set R, G and B values and an alpha value of 1 |
-| Color.New(`number` r, `number` g, `number` b, `number` a) | Creates a new Color with the set R, G, B and A values                      |
+| Color.New(`float` n)                                      | Creates a new Color with an R, G and B value of n.                         |
+| Color.New(`float` r, `float` g, `float` b)                | Creates a new Color with the set R, G and B values and an alpha value of 1 |
+| Color.New(`float` r, `float` g, `float` b, `float` a)     | Creates a new Color with the set R, G, B and A values                      |
 | Color.FromHex(`string` HEX)                               | Creates a new Color from the specified hex value.                          |
 | Color.Random()                                            | Returns a random color with an alpha value of 1.                           |
 
@@ -27,13 +27,13 @@ The alpha property is between 0 and 255. 0 is fully transparent and 255 is fully
 
 | Name       | Description                     |
 | ---------- | ------------------------------- |
-| `number` r | Red color component             |
-| `number` g | Green color component           |
-| `number` b | Blue color component            |
-| `number` a | Alpha (opacity) color component |
+| `float` r  | Red color component             |
+| `float` g  | Green color component           |
+| `float` b  | Blue color component            |
+| `float` a  | Alpha (opacity) color component |
 
 ## Functions
 
 | Name                                          | Description                                |
 | --------------------------------------------- | ------------------------------------------ |
-| Color.Lerp(`Color` a, `Color`, b, `number` t) | Linearly interpolates colors a and b by t. |
+| Color.Lerp(`Color` a, `Color`, b, `float` t)  | Linearly interpolates colors a and b by t. |

--- a/docs/objects/types/NetMessage.md
+++ b/docs/objects/types/NetMessage.md
@@ -17,8 +17,8 @@ icon: polytoria/NetMessage
 | NetMessage.GetString(`string` key)                        | Gets the value of a string key.     |
 | NetMessage.AddInt(`string` key, `int` int)                | Sets a key as an integer.           |
 | NetMessage.GetInt(`string` key)                           | Gets the value of a integer key.    |
-| NetMessage.AddNumber(`string` key, `number` number)       | Sets a key as a number.             |
-| NetMessage.GetNumber(`string` key)                        | Gets the value of a number key.     |
+| NetMessage.AddNumber(`string` key, `float` number)        | Sets a key as a float.              |
+| NetMessage.GetNumber(`string` key)                        | Gets the value of a float key.      |
 | NetMessage.AddBool(`string` key, `boolean` bool)          | Sets a key as a boolean.            |
 | NetMessage.GetBool(`string` key)                          | Gets the value of a boolean key.    |
 | NetMessage.AddVector2(`string` key, `Vector2` Vector2)    | Sets a key as a Vector2.            |

--- a/docs/objects/types/Numbers.md
+++ b/docs/objects/types/Numbers.md
@@ -1,0 +1,75 @@
+---
+title: Numbers
+description: Numbers are a data type holding significant value to scripting.
+icon: polytoria/NumberValue
+---
+
+# Numbers
+
+Numbers are essential to scripting. This page will explain how numbers work and the difference between a float and an integer.
+
+## Number operations
+
+The basic number operations of addition, subtraction, multiplication, division, exponentation, root, modulo and logarithm are possible within Lua and thus within Polytoria.
+
+### Addition
+The addition operation may be done using `+`
+```lua
+local sum = summand1 + summand2
+```
+
+### Subtraction
+The subtraction operation may be done using `-`
+```lua
+local difference = minuend - subtrahend
+```
+
+### Multiplication
+The multiplication operation may be done using `*`
+```lua
+local product = factor1 * factor2
+```
+
+### Division
+The division operation may be done using `/`
+```lua
+local quotient = dividend / divisor
+```
+
+### Exponentation
+The exponentation operation may be done using `^` or `math.pow()`
+```lua
+local power = base^exponent
+local power2 = math.pow(base^exponent)
+```
+
+### Root
+The root operation may be done using `^` with an exponent higher than 0, but lower than 1. To perform a nth root you may use the exponent `(1/n)`.
+For square roots you may use `math.sqrt()`
+```lua
+local squareRoot = 16^0.5
+local squareRoot2 = math.sqrt(16)
+local thirdRoot = 27^(1/3)
+```
+
+### Modulo
+The modulo operation may be done using `%`.
+```lua
+local remainder = 14 % 5
+```
+
+### Logarithm
+The logarithm operation may be done using `math.log()`
+```lua
+local logarithm = math.log(antilogarithm, base)
+```
+
+### See also
+The [Lua 5.2 Reference](https://lua.org/manual/5.2/manual.html#6.6) for more operations possible with a number.
+
+## Floats and Integers
+You may have noticed that the documentation mentions `float` and `int`, but never `number`, when Lua only has the `number`data type.
+
+Floats are decimal numbers, while integers are whole numbers. This distinction is important to let you know what kind of information you may give or receive.
+
+Let's take player User IDs as an example: User IDs are whole numbers, but never numbers with a decimal component.

--- a/docs/objects/types/RayResult.md
+++ b/docs/objects/types/RayResult.md
@@ -14,5 +14,5 @@ icon: polytoria/RayResult
 | ------------------- | ---------------------------------------- |
 | `Instance` Instance | The instance hit by the raycast.         |
 | `Vector3` Position  | The position the ray made contact at.    |
-| `number` Distance   | The distance between the hit and origin. |
+| `float` Distance    | The distance between the hit and origin. |
 | `Vector3` Normal    | The normal of the surface the ray hit.   |

--- a/docs/objects/types/Vector2.md
+++ b/docs/objects/types/Vector2.md
@@ -13,21 +13,21 @@ icon: polytoria/Vector2
 | Name                                | Description                                       |
 | ----------------------------------- | ------------------------------------------------- |
 | Vector2.New()                       | Creates a new Vector.                             |
-| Vector2.New(`number` n)             | Creates a new Vector2 with an X and Y value of n. |
-| Vector2.New(`number` x, `number` y) | Creates a new Vector2 with the specified values.  |
+| Vector2.New(`float` n)             | Creates a new Vector2 with an X and Y value of n. |
+| Vector2.New(`float` x, `float` y) | Creates a new Vector2 with the specified values.  |
 
 ## Properties
 
 | Name                  | Description                               |
 | --------------------- | ----------------------------------------- |
-| `number` x            | The X component of the vector             |
-| `number` y            | The Y component of the vector             |
-| `number` magnitude    | The length of this vector                 |
-| `number` sqrMagnitude | The squared length of this vector         |
-| `number` normalized   | Returns this vector with a magnitude of 1 |
+| `float` x             | The X component of the vector             |
+| `float` y             | The Y component of the vector             |
+| `float` magnitude     | The length of this vector                 |
+| `float` sqrMagnitude  | The squared length of this vector         |
+| `float` normalized    | Returns this vector with a magnitude of 1 |
 
 ## Methods
 
 | Name                                                         | Description                               |
 | ------------------------------------------------------------ | ----------------------------------------- |
-| `Vector2` Vector2.Lerp(`Vector2` a, `Vector2` b, `number` t) | Linearly interpolates between two points. |
+| `Vector2` Vector2.Lerp(`Vector2` a, `Vector2` b, `float` t)  | Linearly interpolates between two points. |

--- a/docs/objects/types/Vector3.md
+++ b/docs/objects/types/Vector3.md
@@ -13,41 +13,41 @@ icon: polytoria/Vector3
 | Name                                            | Description                                                                  |
 | ----------------------------------------------- | ---------------------------------------------------------------------------- |
 | Vector3.New()                                   | Creates a new Vector.                                                        |
-| Vector3.New(`number` n)                         | Creates a new Vector3 with an X, Y and Z value of n.                         |
-| Vector3.New(`number` x, `number` y)             | Creates a new Vector3 with X and Y set to the specified values and a Z of 0. |
-| Vector3.New(`number` x, `number` y, `number` z) | Creates a new Vector3 with the specified values.                             |
+| Vector3.New(`float` n)                          | Creates a new Vector3 with an X, Y and Z value of n.                         |
+| Vector3.New(`float` x, `float` y)               | Creates a new Vector3 with X and Y set to the specified values and a Z of 0. |
+| Vector3.New(`float` x, `float` y, `float` z)    | Creates a new Vector3 with the specified values.                             |
 
 ## Properties
 
-| Name                  | Description                               |
-| --------------------- | ----------------------------------------- |
-| `number` x            | The X component of the vector             |
-| `number` y            | The Y component of the vector             |
-| `number` z            | The Z component of the vector             |
-| `number` magnitude    | The length of this vector                 |
-| `number` sqrMagnitude | The squared length of this vector         |
-| `number` normalized   | Returns this vector with a magnitude of 1 |
+| Name                 | Description                               |
+| -------------------- | ----------------------------------------- |
+| `float` x            | The X component of the vector             |
+| `float` y            | The Y component of the vector             |
+| `float` z            | The Z component of the vector             |
+| `float` magnitude    | The length of this vector                 |
+| `float` sqrMagnitude | The squared length of this vector         |
+| `float` normalized   | Returns this vector with a magnitude of 1 |
 
 ## Methods
 
 | Name                                                                                                                                           | Description                                                                                                                                 |
 | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | Vector3.Angle(`Vector3` from, `Vector3` to)                                                                                                    | Returns the angle in degrees between from and to.                                                                                           |
-| Vector3.ClampMagnitude(`Vector3` vector, `number` maxLength)                                                                                   | Returns a copy of this vector with its magnitude clamped to maxLength                                                                       |
+| Vector3.ClampMagnitude(`Vector3` vector, `float` maxLength)                                                                                    | Returns a copy of this vector with its magnitude clamped to maxLength                                                                       |
 | Vector3.Cross(`Vector3` a, `Vector3` b)                                                                                                        | Cross product of two vectors.                                                                                                               |
 | Vector3.Distance(`Vector3` a, `Vector3` b)                                                                                                     | Returns the distance between a and b                                                                                                        |
 | Vector3.Dot(`Vector3` a, `Vector3` b)                                                                                                          | Dot product of two vectors                                                                                                                  |
-| Vector3.Lerp(`Vector3` a, `Vector3` b, `number` t)                                                                                             | Linearly interpolates between two points.                                                                                                   |
+| Vector3.Lerp(`Vector3` a, `Vector3` b, `float` t)                                                                                              | Linearly interpolates between two points.                                                                                                   |
 | Vector3.Max(`Vector3` a, `Vector3` b)                                                                                                          | Returns a vector that is made from the largest components of two vectors.                                                                   |
 | Vector3.Min(`Vector3` a, `Vector3` b)                                                                                                          | Returns a vector that is made from the smallest components of two vectors.                                                                  |
-| Vector3.MoveTowards(`Vector3` current, `Vector3` target, `number` maxDistanceDelta)                                                            | Calculate a position between the points specified by current and target, moving no farther than the distance specified by maxDistanceDelta. |
+| Vector3.MoveTowards(`Vector3` current, `Vector3` target, `float` maxDistanceDelta)                                                             | Calculate a position between the points specified by current and target, moving no farther than the distance specified by maxDistanceDelta. |
 | Vector3.Normalize(`Vector3` value)                                                                                                             | Makes this vector have a magnitude of 1.                                                                                                    |
 | Vector3.Project(`Vector3` vector, `Vector3` onNormal)                                                                                          | Projects a vector onto another vector.                                                                                                      |
 | Vector3.ProjectOnPlane(`Vector3` vector, `Vector3` planeNormal)                                                                                | Projects a vector onto a plane defined by a normal orthogonal to the plane.                                                                 |
 | Vector3.Reflect(`Vector3` inDirection, `Vector3` inNormal)                                                                                     | Reflects a vector off the plane defined by a normal.                                                                                        |
-| Vector3.RotateTowards(`Vector3` current, `Vector3` target, `number` maxRadiansDelta, `number` maxMagnitudeDelta)                               | Rotates a vector current towards target.                                                                                                    |
+| Vector3.RotateTowards(`Vector3` current, `Vector3` target, `float` maxRadiansDelta, `float` maxMagnitudeDelta)                                 | Rotates a vector current towards target.                                                                                                    |
 | Vector3.Scale(`Vector3` a, `Vector3` b)                                                                                                        | Multiplies two vectors component-wise.                                                                                                      |
 | Vector3.SignedAngle(`Vector3` from, `Vector3` to, `Vector3` axis)                                                                              | Returns the signed angle in degrees between from and to.                                                                                    |
 | Vector3.Slerp(`Vector3` a, `Vector3` b)                                                                                                        | Spherically interpolates between two vectors.                                                                                               |
 | Vector3.SlerpUnclamped(`Vector3` a, `Vector3` b)                                                                                               | Spherically interpolates between two vectors.                                                                                               |
-| Vector3.SmoothDamp(`Vector3` current, `Vector3` target, `Vector3` currentVelocity, `number` smoothTime, `number` maxSpeed, `number` deltaTime) | Gradually changes a vector towards a desired goal over time.                                                                                |
+| Vector3.SmoothDamp(`Vector3` current, `Vector3` target, `Vector3` currentVelocity, `float` smoothTime, `float` maxSpeed, `float` deltaTime)    | Gradually changes a vector towards a desired goal over time.                                                                                |

--- a/docs/objects/ui/PlayerGUI.md
+++ b/docs/objects/ui/PlayerGUI.md
@@ -15,6 +15,6 @@ weight: 100
 
 Whether or not the player can interact with the GUI.
 
-### Opacity:int { property }
+### Opacity:float { property }
 
 The opacity of the player's GUI.

--- a/docs/objects/ui/UIField.md
+++ b/docs/objects/ui/UIField.md
@@ -53,7 +53,7 @@ The offset of the UI element in pixels.
 
 The position of the UI element relative to its parent.
 
-### Rotation:int { property }
+### Rotation:float { property }
 
 The rotation of the UI element.
 

--- a/docs/objects/ui/UIHVLayout.md
+++ b/docs/objects/ui/UIHVLayout.md
@@ -61,6 +61,6 @@ Specifies the top padding of the UIHVLayout.
 
 Specifies if the alignment is reversed.
 
-### Spacing:int { property }
+### Spacing:float { property }
 
 Specifies the spacing between child.

--- a/docs/objects/ui/UILabel.md
+++ b/docs/objects/ui/UILabel.md
@@ -21,7 +21,7 @@ Whether the text should be automatically sized to fit the label's size.
 
 The font of the label.
 
-### FontSize:int { property }
+### FontSize:float { property }
 
 The font size of the label.
 
@@ -29,7 +29,7 @@ The font size of the label.
 
 Determines how the text is justified.
 
-### MaxFontSize:int { property }
+### MaxFontSize:float { property }
 
 The maximum font size of the UI element if AutoSize is set to true.
 

--- a/docs/objects/ui/UITextInput.md
+++ b/docs/objects/ui/UITextInput.md
@@ -59,7 +59,7 @@ The font of the label.
 element.Font = TextFontPreset.Montserrat
 ```
 
-### FontSize:int { property }
+### FontSize:float { property }
 
 The font size of the label.
 
@@ -99,7 +99,7 @@ Determines how the text is justified.
 element.JustifyText = TextJustify.Center
 ```
 
-### MaxFontSize:int { property }
+### MaxFontSize:float { property }
 
 The maximum font size of the UI element if AutoSize is set to true.
 

--- a/docs/objects/ui/UIView.md
+++ b/docs/objects/ui/UIView.md
@@ -23,7 +23,7 @@ Determines the border color of the UI.
 element.BorderColor = Color.New(1, 0, 0, 1)
 ```
 
-### BorderWidth:int { property }
+### BorderWidth:float { property }
 
 Determines the border width of the UI.
 
@@ -43,7 +43,7 @@ Determines the color of the UI.
 element.Color = Color.New(0, 0, 0, 1)
 ```
 
-### CornerRadius:int { property }
+### CornerRadius:float { property }
 
 Determines the corner radius of the UI.
 

--- a/docs/objects/values/NumberValue.md
+++ b/docs/objects/values/NumberValue.md
@@ -1,13 +1,13 @@
 ---
 title: NumberValue
-description: NumberValue is a ValueBase that stores numbers.
+description: NumberValue is a ValueBase that stores floats.
 icon: polytoria/NumberValue
 weight: 10
 ---
 
 # NumberValue
 
-:polytoria-NumberValue: NumberValue is a ValueBase that stores numbers.
+:polytoria-NumberValue: NumberValue is a ValueBase that stores floats.
 
 {{ inherits("ValueBase") }}
 

--- a/docs/objects/values/ValueBase.md
+++ b/docs/objects/values/ValueBase.md
@@ -7,7 +7,7 @@ weight: 20
 
 # ValueBase
 
-{{ ambiguousMultiple([["BoolValue", "used for storing bool values."], ["ColorValue", "used for storing color values."], ["InstanceValue", "used for storing instances."], ["IntValue", "used for storing integer values."], ["NumberValue", "used for storing number values."], ["StringValue", "used for storing string values."], ["Vector3Value", "used for storing Vector3 values."]])}}
+{{ ambiguousMultiple([["BoolValue", "used for storing bool values."], ["ColorValue", "used for storing color values."], ["InstanceValue", "used for storing instances."], ["IntValue", "used for storing integer values."], ["NumberValue", "used for storing float values."], ["StringValue", "used for storing string values."], ["Vector3Value", "used for storing Vector3 values."]])}}
 
 Base class of all value classes.
 

--- a/docs/objects/world/Climbable.md
+++ b/docs/objects/world/Climbable.md
@@ -14,6 +14,6 @@ weight: 100
 
 ## Properties
 
-### ClimbSpeed:int { property }
+### ClimbSpeed:float { property }
 
 Determines how fast a player can climb the object.

--- a/docs/objects/world/MeshPart.md
+++ b/docs/objects/world/MeshPart.md
@@ -40,7 +40,7 @@ The asset ID of the mesh part.
 
 Specifies whether the part can be collided with or not.
 
-### Mass:int { property }
+### Mass:float { property }
 
 Specifies the mass of a part in kilograms.
 

--- a/docs/objects/world/NPC.md
+++ b/docs/objects/world/NPC.md
@@ -68,7 +68,7 @@ Returns true if the NPC is currently standing on the ground.
 
 Specifies the color of the NPC's head.
 
-### Health:int { property }
+### Health:float { property }
 
 Specifies the current amount of health the NPC has.
 
@@ -76,11 +76,11 @@ Specifies the current amount of health the NPC has.
 
 Determines the instance the NPC should walk towards.
 
-### WalkSpeed:int { property }
+### WalkSpeed:float { property }
 
 Determines the walkspeed of the NPC.
 
-### MaxHealth:int=100 { property }
+### MaxHealth:float=100 { property }
 
 Specifies the maximum amount of health a NPC can have.
 

--- a/docs/objects/world/Part.md
+++ b/docs/objects/world/Part.md
@@ -40,11 +40,11 @@ game["Environment"]["Part"]:MovePosition(Vector3.New(0, 180, 0))
 
 Specifies whether the part is to be affected by physics or not.
 
-### AngularDrag:int { property }
+### AngularDrag:float { property }
 
 Angular drag (air resistance) of this part.
 
-### AngularDrag:int { property }
+### AngularDrag:float { property }
 
 Angular drag (air resistance) of this part.
 
@@ -60,7 +60,7 @@ Specifies whether the part can be collided with or not.
 
 Specifies the color of a part.
 
-### Drag:int { property }
+### Drag:float { property }
 
 Determines Drag (air resistance) of this part.
 
@@ -76,7 +76,7 @@ Determines whether to display studs on the part or not.
 
 Specifies whether the part can be used as a spawn location or not.
 
-### Mass:int { property }
+### Mass:float { property }
 
 Specifies the mass of a part in kilograms.
 

--- a/docs/objects/world/Text3D.md
+++ b/docs/objects/world/Text3D.md
@@ -39,7 +39,7 @@ text.FaceCamera = true
 
 Specifies the font of the text (using the `TextFontPreset` enum)
 
-### FontSize:int { property }
+### FontSize:float { property }
 
 Specifies the size of the font.
 

--- a/main.py
+++ b/main.py
@@ -158,15 +158,11 @@ def define_env(env):
 
 # define list of friendly names for method and property types
 type_friendlyname_table = {
-    "int": "number",
-    "float": "number",
     "bool": "boolean",
     "array": "[]"
 }
 
 parametertype_friendlyname_table = {
-    "int": "number",
-    "float": "number",
     "bool": "boolean"
 }
 


### PR DESCRIPTION
## PR Summary
Gets rid of the friendly names for floats and ints so that "number" doesn't show up anymore (as suggested by Alyx)
Adds a page documentating number operations as well as the difference between between a float and an integer
Replaces many cases of "number" with "float" as well as many incorrect cases of floats being written down as an integer

Thanks for taking the time to contribute to the Polytoria documentation project!
Please ensure that this PR meets the following criteria before submitting (you may delete this section after reading):

- [X] The changes you've made are accurate and correct
- [X] Distinct changes for separate issues are in separate PRs (do not combine multiple issues into one PR)
- [X] Any additions or modifications to the example code were tested in the latest version of Polytoria Creator and work as intended
