### PR TITLE
omit method return type if return type is void

### DIFF
--- a/docs/objects/game/Player.md
+++ b/docs/objects/game/Player.md
@@ -17,14 +17,14 @@ weight: 5
 
 ## Events
 
-### Chatted(message;string) { event }
+### Chatted(message;string,event;table={Player|message|Cancelled}) { event }
 
-Fires when the player sends a chat message.
+Fires when the player sends a chat message. You can cancel the chat message by setting the event's `Cancelled` property like this: `event.Cancelled = true`.
 
 **Example**
 
 ```lua
-game["Players"]["willemsteller"].Chatted:Connect(function (message)
+game["Players"]["willemsteller"].Chatted:Connect(function (message, event)
     print("Player wrote: " .. message)
 end)
 ```

--- a/main.py
+++ b/main.py
@@ -264,11 +264,11 @@ def method(name):
         if getClassLink(property_type) != "?":
             property_type = getClassLink(property_type)
             has_link = True
-    else:
-        property_type = "void"
 
-    if has_link == False:
-        property_type = "`" + property_type + "`"
+    if property_type != "":
+        if has_link == False:
+            property_type = "`" + property_type + "`"
+        property_type = "→ " + property_type
 
     parametersList = ""
 
@@ -313,7 +313,7 @@ def method(name):
         elif len(parameters) == 1:
             parametersList = f"\n!!! quote \"**Parameters:** <span style=\"font-weight: normal;\">" + parameters[0] + "</span>\""
 
-    return "### :polytoria-Method: %s → %s { #%s data-toc-label=\"%s\" }%s" % (name, property_type, name, name, parametersList)
+    return "### :polytoria-Method: %s %s { #%s data-toc-label=\"%s\" }%s" % (name, property_type, name, name, parametersList)
 
 def on_pre_page_macros(env):
     #find headers with { macroName } at the end and replace with the associated macro


### PR DESCRIPTION
Fixes #104 

## omit method return type if return type is void

- [x] The changes you've made are accurate and correct
- [x] Distinct changes for separate issues are in separate PRs (do not combine multiple issues into one PR)
- [x] Any additions or modifications to the example code were tested in the latest version of Polytoria Creator and work as intended
