### PR TITLE
Document ".Bounciness" and ".Friction" properties of Part class

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for waiting to contribute to the new unofficial Polytoria documentation! 
 | -------------------------- | ------- |
 | mkdocs                     | 1.6.0   |
 | mkdocs-macros-plugin       | 1.0.5   |
-| mkdocs-material            | 9.5.33   |
+| mkdocs-material            | 9.5.33  |
 | mkdocs-material-extensions | 1.3.1   |
 | mkdocs-nav-weight          | 0.2.0   |
 | pymdown-extensions         | 10.9    |

--- a/docs/objects/world/Part.md
+++ b/docs/objects/world/Part.md
@@ -52,6 +52,10 @@ Angular drag (air resistance) of this part.
 
 Specifies the angular velocity of a part.
 
+### Bounciness:float { property }
+
+Determines how bouncy the part is when players land on it.
+
 ### CanCollide:bool { property }
 
 Specifies whether the part can be collided with or not.
@@ -63,6 +67,10 @@ Specifies the color of a part.
 ### Drag:float { property }
 
 Determines Drag (air resistance) of this part.
+
+### Friction:float { property }
+
+Determines the amount of friction between the part and players on it.
 
 ### Forward:Vector3 { property }
 


### PR DESCRIPTION
## Document ".Bounciness" and ".Friction" properties of Part class

Despite ".BouncinessCombine" and ".FrictionCombine" said to be added here: https://polytoria.com/forum/post/344969 - they do not exist in the scripting API dump XML.

- Document ".Bounciness" property of Part class
- Document ".Friction" property of Part class

- [x] The changes you've made are accurate and correct
- [x] Distinct changes for separate issues are in separate PRs (do not combine multiple issues into one PR)
- [x] Any additions or modifications to the example code were tested in the latest version of Polytoria Creator and work as intended
