### PR TITLE
Add graphs to TweenType (+ minor changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Polytoria simplifies your multiplayer game development. Easy to get started for 
 
 ## Installation Instructions
 
-1. Install the dependancies via the  `fast-setup.py` file, this requires `pip` to be installed.
+1. Install the dependancies with [pip](https://pypi.org/project/pip/) by running `pip install -r .\requirements.txt`
 2. Run `mkdocs serve`
 3. Input `http://127.0.0.1:8000/` into browser to view locally to edit.

--- a/docs/objects/enums/TweenType.md
+++ b/docs/objects/enums/TweenType.md
@@ -6,37 +6,37 @@ icon: polytoria/Enum
 
 # TweenType
 
-| Name             |
-| ---------------- |
-| easeInBack       |
-| easeInBounce     |
-| easeInCirc       |
-| easeInCubic      |
-| easeInElastic    |
-| easeInExpo       |
-| easeInOutBack    |
-| easeInOutBounce  |
-| easeInOutCirc    |
-| easeInOutCubic   |
-| easeInOutElastic |
-| easeInOutExpo    |
-| easeInOutQuad    |
-| easeInOutQuart   |
-| easeInOutQuint   |
-| easeInOutSine    |
-| easeInQuad       |
-| easeInQuart      |
-| easeInQuint      |
-| easeInSine       |
-| easeOutBack      |
-| easeOutBounce    |
-| easeOutCirc      |
-| easeOutCubic     |
-| easeOutElastic   |
-| easeOutExpo      |
-| easeOutQuad      |
-| easeOutQuart     |
-| easeOutQuint     |
-| easeOutSine      |
-| linear           |
-| punch            |
+| Name             | Graph
+| ---------------- | --------------------- |
+| easeInBack       | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84c44 1 81.5 48.6 123-83" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInBounce     | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84l.24-.51 1.24-.39 1.24-.26 1.24-.13 1.24-.01 1.24.12 1.24.25 1.24.38 1.24.5L12.4 83l1.24-.97 1.24-.85 1.24-.72 1.24-.6 1.24-.47 1.24-.34 1.24-.21 1.24-.09 1.24.04 1.24.17 1.24.29 1.24.43 1.24.54 1.24.68 1.24.8 1.24.93 1.24 1.06 1.24-1.34 1.24-2.15 1.24-2.03 1.24-1.9 1.24-1.77 1.24-1.65 1.24-1.52 1.24-1.39 1.24-1.26 1.24-1.14 1.24-1.01 1.24-.88 1.24-.76 1.24-.63 1.24-.5 1.24-.38 1.24-.25 1.24-.12 1.24.01 1.24.13 1.24.26 1.24.39 1.24.51 1.24.64 1.24.77 1.24.9 1.24 1.02 1.24 1.15 1.24 1.27 1.24 1.41L71.92 73l1.24 1.66 1.24 1.78 1.24 1.91 1.24 2.04 1.24 2.17 1.24-.23 1.24-4.51 1.24-4.39 1.24-4.25 1.24-4.13 1.24-4 1.24-3.88 1.24-3.75 1.24-3.62 1.24-3.49 1.24-3.37L93 39.7l1.24-3.11 1.24-2.99 1.24-2.85 1.24-2.74 1.24-2.6 1.24-2.48 1.24-2.35 1.24-2.22 1.24-2.1 1.24-1.97 1.24-1.84 1.24-1.71 1.24-1.59 1.24-1.46 1.24-1.34 1.24-1.2 1.24-1.08 1.24-.96 1.24-.82 1.24-.7 1.24-.57 1.24-.45 1.24-.32 1.24-.19" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInCirc       | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84c67.75 1 124-37.25 123-83" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInCubic      | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84c39 1 82.75 1 123-83" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInElastic    | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84l.24.03 1.24-.02 1.24-.02 1.24-.02 1.24-.03 1.24-.02 1.24-.03 1.24-.02 1.24-.02 1.24-.01 1.24-.01h1.24l1.24.01 1.24.02 1.24.02 1.24.04 1.24.05 1.24.06 1.24.06 1.24.07 1.24.08 1.24.06 1.24.07 1.24.05 1.24.04 1.24.03h1.24l1.24-.03 1.24-.05 1.24-.08 1.24-.11 1.24-.14 1.24-.16 1.24-.19 1.24-.19 1.24-.21 1.24-.19 1.24-.18 1.24-.16 1.24-.11 1.24-.07h1.24l1.24.07 1.24.15 1.24.23 1.24.32 1.24.39 1.24.46 1.24.52 1.24.55 1.24.57 1.24.56 1.24.51 1.24.44 1.24.32 1.24.18 1.24.01 1.24-.2 1.24-.42 1.24-.66 1.24-.88 1.24-1.11 1.24-1.31 1.24-1.46 1.24-1.57 1.24-1.61 1.24-1.58 1.24-1.45 1.24-1.23 1.24-.92 1.24-.51 1.24-.01 1.24.56 1.24 1.19L93 76.58l1.24 2.5 1.24 3.14 1.24 3.69 1.24 4.14 1.24 4.45 1.24 4.56 1.24 4.46 1.24 4.1 1.24 3.48 1.24 2.6 1.24 1.43 1.24.04 1.24-1.59 1.24-3.36 1.24-5.22 1.24-7.09 1.24-8.87 1.24-10.44 1.24-11.73 1.24-12.57 1.24-12.9 1.24-12.6 1.24-11.6 1.24-9.86" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInExpo       | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84c86.5 1 104 1 123-83" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutBack    | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M 1 93 C 85 145 40 -42 124 10" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutBounce  | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84l.24-.45 1.24-.2 1.24.06 1.24.31 1.24-.22 1.24-.91 1.24-.66 1.24-.4 1.24-.15 1.24.1 1.24.36 1.24.61 1.24.87 1.24-.14 1.24-2.09 1.24-1.84 1.24-1.58 1.24-1.33 1.24-1.07 1.24-.83 1.24-.56 1.24-.31 1.24-.06 1.24.2 1.24.45 1.24.7 1.24.96 1.24 1.21 1.24 1.47 1.24 1.72 1.24 1.98 1.24.96 1.24-4.44 1.24-4.2 1.24-3.93 1.24-3.69 1.24-3.43 1.24-3.17 1.24-2.93 1.24-2.67 1.24-2.41 1.24-2.16 1.24-1.9 1.24-1.66 1.24-1.39 1.24-1.15 1.24-.89 1.24-.63 1.24-.38L62 42l1.24-.13 1.24-.38 1.24-.63 1.24-.89 1.24-1.15 1.24-1.39 1.24-1.66 1.24-1.9 1.24-2.16 1.24-2.42 1.24-2.66 1.24-2.93 1.24-3.17 1.24-3.43 1.24-3.69 1.24-3.93 1.24-4.2L84.32.84l1.24.96 1.24 1.98 1.24 1.72 1.24 1.47 1.24 1.21 1.24.96 1.24.7 1.24.45 1.24.2 1.24-.06 1.24-.31 1.24-.57 1.24-.82 1.24-1.07 1.24-1.33 1.24-1.58 1.24-1.84 1.24-2.09 1.24-.14 1.24.87 1.24.61 1.24.36 1.24.1 1.24-.15 1.24-.4 1.24-.66L117.8.5l1.24-.22 1.24.31 1.24.06 1.24-.2" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutCirc    | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C106.25 85 18.75 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutCubic   | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C81.25 85 43.75 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutElastic | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M 1 94 l 0.24 -0.02 l 1.24 -0.02 l 1.24 -0.01 l 1.24 -0.02 l 1.24 -0.01 l 1.24 -0.01 h 1.24 l 1.24 0.01 l 1.24 0.02 l 1.24 0.03 l 1.24 0.05 l 1.24 0.06 l 1.24 0.07 l 1.24 0.08 l 1.24 0.08 l 1.24 0.07 l 1.24 0.04 l 1.24 0.02 l 1.24 -0.03 l 1.24 -0.08 l 1.24 -0.15 l 1.24 -0.21 l 1.24 -0.28 l 1.24 -0.33 l 1.24 -0.37 l 1.24 -0.37 l 1.24 -0.33 l 1.24 -0.26 l 1.24 -0.12 l 1.24 0.08 l 1.24 0.32 l 1.24 0.62 l 1.24 0.93 l 1.24 1.25 l 1.24 1.52 l 1.24 1.71 l 1.24 1.78 l 1.24 1.66 l 1.24 1.34 l 1.24 0.75 l 1.24 -0.11 l 1.24 -1.23 l 1.24 -2.57 l 1.24 -4.05 l 1.24 -5.56 l 1.24 -6.92 l 1.24 -7.97 l 1.24 -8.45 l 1.24 -8.16 L 62 52 l 1.24 -6.85 l 1.24 -8.16 l 1.24 -8.45 l 1.24 -7.97 l 1.24 -6.92 l 1.24 -5.56 l 1.24 -4.05 l 1.24 -2.57 l 1.24 -1.23 l 1.24 -0.11 l 1.24 0.75 l 1.24 1.34 l 1.24 1.66 l 1.24 1.78 l 1.24 1.72 l 1.24 1.51 L 83.08 10.14 l 1.24 0.93 l 1.24 0.62 l 1.24 0.32 l 1.24 0.08 l 1.24 -0.12 l 1.24 -0.26 l 1.24 -0.33 L 93 11.01 l 1.24 -0.37 l 1.24 -0.33 l 1.24 -0.28 l 1.24 -0.21 l 1.24 -0.15 l 1.24 -0.08 l 1.24 -0.03 l 1.24 0.02 l 1.24 0.04 l 1.24 0.07 l 1.24 0.08 l 1.24 0.08 l 1.24 0.07 l 1.24 0.06 l 1.24 0.05 l 1.24 0.03 l 1.24 0.02 l 1.24 0.01 h 1.24 l 1.24 -0.01 l 1.24 -0.01 l 1.24 -0.02 l 1.24 -0.01 l 1.24 -0.02" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutExpo    | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C108.75 85 16.25 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutQuad    | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C56.25 85 68.75 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutQuart   | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C95 85 30 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutQuint   | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C103.75 85 21.25 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInOutSine    | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C46.25 85 78.75 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInQuad       | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84c12.75 1 61.5 1 123-83" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInQuart      | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84c61.5 1 92.75 1 123-83" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInQuint      | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84c79 1 96.5 1 123-83" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeInSine       | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84c14 1 47.75 1 123-83" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutBack      | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M 1 93 C 42.5 -38.6 80 9 124 10" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutBounce    | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84l.24-.06 1.24-.19 1.24-.32 1.24-.45 1.24-.57 1.24-.7 1.24-.82 1.24-.96 1.24-1.08 1.24-1.2 1.24-1.34 1.24-1.46 1.24-1.59 1.24-1.71 1.24-1.84 1.24-1.97 1.24-2.1 1.24-2.22 1.24-2.35 1.24-2.48 1.24-2.6 1.24-2.74 1.24-2.85 1.24-2.99L31 44.3l1.24-3.24 1.24-3.37 1.24-3.49 1.24-3.62 1.24-3.75 1.24-3.88 1.24-4 1.24-4.13 1.24-4.25 1.24-4.39 1.24-4.51 1.24-.23 1.24 2.17 1.24 2.04 1.24 1.91 1.24 1.78L52.08 11l1.24 1.53 1.24 1.41 1.24 1.27 1.24 1.15 1.24 1.02 1.24.9 1.24.77 1.24.64 1.24.51 1.24.39 1.24.26 1.24.13 1.24.01 1.24-.12 1.24-.25 1.24-.38 1.24-.5 1.24-.63 1.24-.76 1.24-.88 1.24-1.01 1.24-1.14 1.24-1.26 1.24-1.39 1.24-1.52 1.24-1.65 1.24-1.77 1.24-1.9 1.24-2.03 1.24-2.15L90.52.31l1.24 1.06L93 2.3l1.24.8 1.24.68 1.24.54 1.24.43 1.24.29 1.24.17 1.24.04 1.24-.09 1.24-.21 1.24-.34 1.24-.47 1.24-.6 1.24-.72 1.24-.85L111.6 1l1.24-.95 1.24.5 1.24.38 1.24.25 1.24.12 1.24-.01 1.24-.13 1.24-.26 1.24-.39" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutCirc      | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C0 38.25 56.25 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutCubic     | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C41.25 0 85 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutElastic   | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M 1 115.5 l 0.24 -7.34 l 1.24 -9.86 l 1.24 -11.6 l 1.24 -12.6 L 6.2 61.2 l 1.24 -12.57 L 8.68 36.9 L 9.92 26.46 l 1.24 -8.87 L 12.4 10.5 l 1.24 -5.22 l 1.24 -3.36 l 1.24 -1.59 l 1.24 0.04 l 1.24 1.43 l 1.24 2.6 l 1.24 3.48 l 1.24 4.1 l 1.24 4.46 l 1.24 4.56 l 1.24 4.45 l 1.24 4.14 l 1.24 3.69 l 1.24 3.14 L 31 38.92 l 1.24 1.85 l 1.24 1.19 l 1.24 0.56 l 1.24 -0.01 l 1.24 -0.51 l 1.24 -0.92 l 1.24 -1.23 l 1.24 -1.45 l 1.24 -1.58 l 1.24 -1.61 l 1.24 -1.57 L 45.88 32.18 l 1.24 -1.31 l 1.24 -1.11 l 1.24 -0.89 l 1.24 -0.65 l 1.24 -0.42 l 1.24 -0.2 l 1.24 0.01 l 1.24 0.18 l 1.24 0.32 l 1.24 0.44 l 1.24 0.51 l 1.24 0.56 l 1.24 0.57 l 1.24 0.55 l 1.24 0.52 l 1.24 0.46 l 1.24 0.39 l 1.24 0.32 l 1.24 0.23 l 1.24 0.15 l 1.24 0.07 h 1.24 l 1.24 -0.07 l 1.24 -0.11 l 1.24 -0.16 l 1.24 -0.18 l 1.24 -0.19 L 80.6 31.96 l 1.24 -0.19 l 1.24 -0.19 l 1.24 -0.16 l 1.24 -0.14 l 1.24 -0.11 l 1.24 -0.08 l 1.24 -0.05 l 1.24 -0.03 h 1.24 L 93 31.04 l 1.24 0.04 l 1.24 0.05 l 1.24 0.07 l 1.24 0.06 l 1.24 0.08 l 1.24 0.07 l 1.24 0.06 l 1.24 0.06 l 1.24 0.05 l 1.24 0.04 l 1.24 0.02 l 1.24 0.02 l 1.24 0.01 h 1.24 l 1.24 -0.01 l 1.24 -0.01 l 1.24 -0.02 l 1.24 -0.02 l 1.24 -0.03 l 1.24 -0.02 l 1.24 -0.03 l 1.24 -0.02 l 1.24 -0.02 l 1.24 -0.02" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutExpo      | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C20 0 37.5 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutQuad      | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C62.5 0 111.25 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutQuart     | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C31.25 0 62.5 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutQuint     | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C27.5 0 45 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| easeOutSine      | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M1 84C76.25 0 110 0 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| linear           | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 125"><path d="M 1 84 L 124 1" fill="none" stroke="currentColor" stroke-width="2px"></path></svg> |
+| punch            | (Unknown) |

--- a/fast-setup.py
+++ b/fast-setup.py
@@ -1,8 +1,0 @@
-import subprocess 
-import sys
-
-print("Please wait one moment while we check everything! :3")
-
-p = subprocess.Popen(["pip", "install", "mkdocs", "mkdocs-macros-plugin", "mkdocs-material", "mkdocs-material", "mkdocs-nav-weight"])
-
-p.communicate();

--- a/main.py
+++ b/main.py
@@ -249,7 +249,7 @@ def event(name):
             parameters[i] = v
 
         if len(parameters) > 1:
-            parametersList = f"\n??? quote \"Parameters\"\n{'\n\n'.join(['\t' + item for item in parameters])}"
+            parametersList = f"\n??? quote \"Parameters\"\n" + "\n\n".join(["    " + item for item in parameters])
         elif len(parameters) == 1:
             parametersList = f"\n!!! quote \"**Parameters:** <span style=\"font-weight: normal;\">" + parameters[0] + "</span>\""
 
@@ -313,7 +313,7 @@ def method(name):
             parameters[i] = v
 
         if len(parameters) > 1:
-            parametersList = f"\n??? quote \"Parameters\"\n{'\n\n'.join(['\t' + item for item in parameters])}"
+            parametersList = "\n??? quote \"Parameters\"\n" + "\n\n".join(['    ' + item for item in parameters])
         elif len(parameters) == 1:
             parametersList = f"\n!!! quote \"**Parameters:** <span style=\"font-weight: normal;\">" + parameters[0] + "</span>\""
 


### PR DESCRIPTION
Felt that it was needed to visualize what all the TweenTypes looks like so I integrated them into the docs! Only one missing is "Punch" which I couldn't find anything on. All graphs courtesy of [easings.net](https://easings.net), some modified to fit in the 125x125 viewbox.

![127 0 0 1_8000_objects_enums_TweenType_](https://github.com/user-attachments/assets/7caedf2a-7ec4-4a8a-a7cb-177ff03624c0)

When trying to setup the Docs environment, I ran into an error of "f-string expression part cannot include a backslash" so I made a quick fix.

```
  File "D:\Projects\Docs\main.py", line 316
    parametersList = f"\n??? quote \"Parameters\"\n{'\n\n'.join(['\t' + item for item in parameters])}"
                                                                                                       ^
SyntaxError: f-string expression part cannot include a backslash
```

I also removed #125's "fast_setup.py" script, which installs the dependencies, in favor of using `pip install -r requirements.txt` as it follows the version specifications listed inside of requirements.txt and is already being used in the deploy workflow.

