### PR TITLE
Updated ModuleScript "BETA Feature" Warning

### DIFF
--- a/docs/objects/scripting/ModuleScript.md
+++ b/docs/objects/scripting/ModuleScript.md
@@ -10,11 +10,9 @@ weight: 3
 <div data-search-exclude markdown>
 !!! bug "BETA Feature"
 
-    ModuleScripts are currently in BETA and its behaviour may change at any point, so use it at your own risk. As of right now, you aren't able to run functions from ModuleScripts. However this is a planned feature in the near future.
+    ModuleScripts are currently in BETA and its behaviour may change at any point, so use it at your own risk.
 
     Current Issues:
-
-    - You can't call functions that are imported from a ModuleScript
 
     - You can't edit data such as tables that are imported from a ModuleScript
 


### PR DESCRIPTION
## Updated ModuleScript "BETA Feature" Warning

The ModuleScript class's "BETA feature" warning textbox, no longer says functions cannot be called, as they can. I am not sure about the editing tables, but I assume that was still not added.

- [x] The changes you've made are accurate and correct
- [x] Distinct changes for separate issues are in separate PRs (do not combine multiple issues into one PR)
- [x] Any additions or modifications to the example code were tested in the latest version of Polytoria Creator and work as intended
