### PR TITLE
minor typo fix (Numbers.md)

### DIFF
--- a/docs/objects/types/Numbers.md
+++ b/docs/objects/types/Numbers.md
@@ -50,7 +50,7 @@ The exponentation operation may be done using `^` or `math.pow()`
 
 ```lua
 local power = base^exponent
-local power2 = math.pow(base^exponent)
+local power2 = math.pow(base, exponent)
 ```
 
 ### Root


### PR DESCRIPTION
## PR Summary

fix #145

`math.pow(base^exponent)` resolves to `math.pow(number)` which isn't representative of the function

Thanks for taking the time to contribute to the Polytoria documentation project!
Please ensure that this PR meets the following criteria before submitting (you may delete this section after reading):

- [X] The changes you've made are accurate and correct
- [X] Distinct changes for separate issues are in separate PRs (do not combine multiple issues into one PR)
- [X] Any additions or modifications to the example code were tested in the latest version of Polytoria Creator and work as intended
