### PR TITLE
update copyright to 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Polytoria Scripting Documentation
-copyright: Copyright &copy; 2019 - 2025 Polytoria - <a href="/contributors" class="contributors-link-footer">brought to you by &lt3</a>
+copyright: Copyright &copy; 2019 - 2026 Polytoria - <a href="/contributors" class="contributors-link-footer">brought to you by &lt3</a>
 
 theme:
   features:


### PR DESCRIPTION
I noticed that the copyright said 2019 - 2025 instead of being updated to 2026. I have updated it to the current year for accuracy.

- [✅] The changes you've made are accurate and correct
- [✅] Distinct changes for separate issues are in separate PRs (do not combine multiple issues into one PR)
- [Not relevant for this pull request] Any additions or modifications to the example code were tested in the latest version of Polytoria Creator and work as intended
