### PR TITLE
remove redundant property entries in Part.md and MeshPart.md

### DIFF
--- a/docs/objects/world/MeshPart.md
+++ b/docs/objects/world/MeshPart.md
@@ -14,14 +14,6 @@ weight: 2
 
 ## Methods
 
-### MovePosition(position;Vector3) { method }
-
-Moves the MeshPart to the specified position.
-
-### MoveRotation(rotation;Vector3) { method }
-
-Rotates the MeshPart to the specified rotation.
-
 ### PlayAnimation(animationName;string,objectPath;string=nil,speed;float=1,loop;bool=false) { method }
 
 Plays the animation with the specified name, if it exists.
@@ -40,37 +32,9 @@ Returns the names of the animations associated with the mesh.
 
 ## Properties
 
-### Anchored:bool { property }
-
-Specifies whether the part is to be affected by physics or not.
-
-### AngularVelocity:Vector3 = Vector3.New(0, 0, 0) { property }
-
-Specifies the angular velocity of a part.
-
 ### AssetID:int { property }
 
 The asset ID of the mesh part.
-
-### CanCollide:bool { property }
-
-Specifies whether the part can be collided with or not.
-
-### Mass:float { property }
-
-Specifies the mass of a part in kilograms.
-
-### Material:PartMaterial { property }
-
-Specifies the material of the part.
-
-### Shape:PartShape { property }
-
-Specifies the shape of a part.
-
-### Velocity:Vector3 = Vector3.New(0, 100, 0) { property }
-
-Specifies the velocity of a part.
 
 ### CurrentAnimation:string { property }
 

--- a/docs/objects/world/Part.md
+++ b/docs/objects/world/Part.md
@@ -92,10 +92,6 @@ Determines Drag (air resistance) of this part.
 
 Determines the amount of friction between the part and players on it.
 
-### Forward:Vector3 { property }
-
-Returns the forward vector of the part
-
 ### HideStuds:bool { property }
 
 Determines whether to display studs on the part or not.


### PR DESCRIPTION
## PR Summary

`Forward` is already present in `DynamicInstance`, and thus in `Part` by means of inheritance
some other properties are present in `MeshPart`'s documentation which are redundancies of `Part`

Thanks for taking the time to contribute to the Polytoria documentation project!
Please ensure that this PR meets the following criteria before submitting (you may delete this section after reading):

- [x] The changes you've made are accurate and correct
- [x] Distinct changes for separate issues are in separate PRs (do not combine multiple issues into one PR)
- [x] Any additions or modifications to the example code were tested in the latest version of Polytoria Creator and work as intended
