### PR TITLE
Add information about 2.0 w/ "2.0 is here!" banner

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -38,3 +38,11 @@ h3 + .admonition.quote {
 .contributors-link-footer {
 	color: #007bff !important;
 }
+
+.banner {
+    width: 100%;
+    text-align: center;
+    background-color: #784343;
+	padding: 15px;
+	color: #fff;
+}

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -1,119 +1,76 @@
-<!--
-  FRONTEND CREATED BY INDEX
-  DESIGN CREATED BY https://github.com/SK-Fast
-  ART CREATED BY https://github.com/SK-Fast
-  CONTRIBUTORS/COMMITS SCRIPT CREATED BY https://github.com/StarManTheGamer
--->
 <!doctype html>
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>Polytoria Scripting API</title>
+		<meta name="robots" content="index, follow" />
+		<meta name="author" content="Polytoria" />
+		<meta name="description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API." />
+		<link rel="canonical" href="https://docs.polytoria.com" />
+		<link rel="icon" href="images/favicon.ico" type="image/x-icon" />
+
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://docs.polytoria.com" />
+		<meta property="og:title" content="Polytoria Scripting API — Kickstart Your Ideas to Reality" />
+		<meta property="og:description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API. Easy for beginners, welcoming for advanced developers." />
+		<meta property="og:image" content="images/popup-background.png" />
+
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content="Polytoria Scripting API — Kickstart Your Ideas to Reality" />
+		<meta name="twitter:description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API." />
+		<meta name="twitter:image" content="images/popup-background.png" />
+
+		<title>Polytoria Scripting Docs</title>
+
 		<link rel="stylesheet" href="style.css" type="text/css" />
+		<link rel="stylesheet" href="/assets/extra.css" type="text/css" />
 		<link
 			href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
 			rel="stylesheet"
 			integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
 			crossorigin="anonymous"
 		/>
-		<link href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css" rel="stylesheet" />
+		<link
+			href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css"
+			rel="stylesheet"
+			integrity="sha384-cTQGMqRSW1uONNQVzr1E0bSxQDSaFR0BjHMYRfXEBNZSGAQ1MhQFAJqUgWMORiA"
+			crossorigin="anonymous"
+		/>
+
 		<meta name="theme-color" content="#2094f3" />
-		<meta name="title" content="Polytoria Scripting API - Contributors" />
-		<meta name="description" content="The Polytoria Scripting API is brought to you by... &lt;3" />
-		<style>
-			body {
-				font-family: Arial, sans-serif;
-				margin: 0;
-				padding: 0;
-				overflow: hidden;
-			}
-
-			.container {
-				max-width: 1200px;
-				margin: 0 auto;
-				padding: 0 15px;
-			}
-
-			.contributors {
-				overflow-x: auto;
-				white-space: nowrap;
-				padding: 20px 0;
-			}
-
-			.text-center {
-				position: relative;
-				z-index: 1;
-			}
-
-			.contributor {
-				display: inline-block;
-				margin-right: 20px;
-				padding: 10px;
-				border: 3px solid #484848;
-				border-radius: 5px;
-				text-align: center;
-				background-color: #252525;
-			}
-
-			.avatar {
-				width: 60px;
-				height: 60px;
-				border-radius: 50%;
-				margin-bottom: 10px;
-			}
-
-			.name {
-				font-weight: bold;
-				display: block;
-				margin-bottom: 5px;
-				color: #cdcdcd;
-			}
-
-			.contributions {
-				color: #cdcdcd;
-			}
-
-			@keyframes scroll {
-				0% {
-					transform: translateX(100%);
-				}
-				100% {
-					transform: translateX(-100%);
-				}
-			}
-
-			.contributors-list {
-				display: inline-block;
-				white-space: nowrap;
-				animation: scroll 20s linear infinite;
-			}
-		</style>
 	</head>
 	<body>
-		<!-- ICONS BACKGROUND-->
-		<div
-			style='
-				background-image: url("images/icons-background.png");
-				position: absolute;
-				margin-right: auto;
-				margin-left: auto;
-				margin-top: 4rem;
-				background-repeat: no-repeat;
-				background-position: top center;
-				width: 100%;
-				height: 450px;
-			'
-		></div>
+		<!-- ICONS BACKGROUND (decorative, hidden from assistive tech) -->
+		<div class="hero-icons-bg" role="presentation" aria-hidden="true"></div>
+
+		<div class="banner">
+			<p style="display:inline;">2.0 is coming! Learn more <a href="/whats-next.html" style="color: #007bff !important; text-decoration: underline !important;">here</a>.</p>
+		</div>
 
 		<!-- NAVBAR -->
-		<nav class="navbar navbar-expand-lg w-75 mx-auto">
+		<nav class="navbar navbar-expand-lg w-75 mx-auto" aria-label="Main navigation">
 			<div class="container-fluid">
-				<a class="navbar-brand" href="#">
-					<img src="images/polytoria-white.svg" alt="Polytoria Logo" style="vertical-align: top; margin-top: 1px" />
+				<a class="navbar-brand" href="/" aria-label="Polytoria Docs home">
+					<img
+						src="images/polytoria-white.svg"
+						alt="Polytoria"
+						width="120"
+						height="24"
+						style="vertical-align: top; margin-top: 1px"
+					/>
 					/docs
 				</a>
-				<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+				<button
+					class="navbar-toggler"
+					type="button"
+					data-bs-toggle="collapse"
+					data-bs-target="#navbarContent"
+					aria-controls="navbarContent"
+					aria-expanded="false"
+					aria-label="Toggle navigation"
+				>
 					<span class="navbar-toggler-icon"></span>
 				</button>
 				<div class="collapse navbar-collapse" id="navbarContent">
@@ -122,10 +79,10 @@
 							<a class="nav-link" href="objects/game/Game/">API</a>
 						</li>
 						<li class="nav-item">
-							<a class="nav-link" href="tutorials/basic-scripting/">Tutorials</a>
+							<a class="nav-link" href="tutorials/basic-scripting/about-scripting">Tutorials</a>
 						</li>
 						<li class="nav-item">
-							<a class="nav-link" href="tutorials/getting-started/">Demos</a>
+							<a class="nav-link" href="tutorials/getting-started/introduction">Demos</a>
 						</li>
 						<li class="nav-item">
 							<a class="nav-link" href="contributors">Contributors</a>
@@ -134,8 +91,7 @@
 				</div>
 			</div>
 		</nav>
-
-		<!-- SPACER -->
+<!-- SPACER -->
 		<div style="height: 125px"></div>
 
 		<div class="container">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,56 +1,77 @@
-<!--
-  FRONTEND CREATED BY INDEX
-  DESIGN CREATED BY https://github.com/SK-Fast
-  ART CREATED BY https://github.com/SK-Fast
--->
 <!doctype html>
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>Polytoria Scripting API</title>
+		<meta name="robots" content="index, follow" />
+		<meta name="author" content="Polytoria" />
+		<meta name="description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API." />
+		<link rel="canonical" href="https://docs.polytoria.com" />
+		<link rel="icon" href="images/favicon.ico" type="image/x-icon" />
+
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://docs.polytoria.com" />
+		<meta property="og:title" content="Polytoria Scripting API — Kickstart Your Ideas to Reality" />
+		<meta property="og:description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API. Easy for beginners, welcoming for advanced developers." />
+		<meta property="og:image" content="images/popup-background.png" />
+
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content="Polytoria Scripting API — Kickstart Your Ideas to Reality" />
+		<meta name="twitter:description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API." />
+		<meta name="twitter:image" content="images/popup-background.png" />
+
+		<title>Polytoria Scripting Docs</title>
+
 		<link rel="stylesheet" href="style.css" type="text/css" />
+		<link rel="stylesheet" href="/assets/extra.css" type="text/css" />
 		<link
 			href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
 			rel="stylesheet"
 			integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
 			crossorigin="anonymous"
 		/>
-		<link href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css" rel="stylesheet" />
+		<link
+			href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css"
+			rel="stylesheet"
+			integrity="sha384-cTQGMqRSW1uONNQVzr1E0bSxQDSaFR0BjHMYRfXEBNZSGAQ1MhQFAJqUgWMORiA"
+			crossorigin="anonymous"
+		/>
 
 		<meta name="theme-color" content="#2094f3" />
-		<meta name="title" content="Polytoria Scripting API" />
-		<meta name="description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API." />
 	</head>
-	<body
-		style='
-			background-image: url("images/background.png");
-			background-repeat: no-repeat;
-		'
-	>
-		<!-- ICONS BACKGROUND-->
-		<div
-			style='
-				background-image: url("images/icons-background.png");
-				position: absolute;
-				margin-right: auto;
-				margin-left: auto;
-				margin-top: 4rem;
-				background-repeat: no-repeat;
-				background-position: top center;
-				width: 100%;
-				height: 450px;
-			'
-		></div>
+	<body>
+
+		<!-- ICONS BACKGROUND (decorative, hidden from assistive tech) -->
+		<div class="hero-icons-bg" role="presentation" aria-hidden="true"></div>
+
+		<div class="banner">
+			<p style="display:inline;">2.0 is coming! Learn more <a href="/whats-next.html" style="color: #007bff !important; text-decoration: underline !important;">here</a>.</p>
+		</div>
 
 		<!-- NAVBAR -->
-		<nav class="navbar navbar-expand-lg w-75 mx-auto">
+		<nav class="navbar navbar-expand-lg w-75 mx-auto" aria-label="Main navigation">
 			<div class="container-fluid">
-				<a class="navbar-brand" href="#">
-					<img src="images/polytoria-white.svg" alt="Polytoria Logo" style="vertical-align: top; margin-top: 1px" />
+				<a class="navbar-brand" href="/" aria-label="Polytoria Docs home">
+					<img
+						src="images/polytoria-white.svg"
+						alt="Polytoria"
+						width="120"
+						height="24"
+						style="vertical-align: top; margin-top: 1px"
+					/>
 					/docs
 				</a>
-				<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+				<button
+					class="navbar-toggler"
+					type="button"
+					data-bs-toggle="collapse"
+					data-bs-target="#navbarContent"
+					aria-controls="navbarContent"
+					aria-expanded="false"
+					aria-label="Toggle navigation"
+				>
 					<span class="navbar-toggler-icon"></span>
 				</button>
 				<div class="collapse navbar-collapse" id="navbarContent">
@@ -72,126 +93,76 @@
 			</div>
 		</nav>
 
-		<!-- SPACER -->
-		<div style="height: 125px"></div>
+		<div class="spacer-lg"></div>
 
 		<div class="text-center w-100">
+
 			<!-- TITLE -->
-			<h1 class="main-title">Kickstart your Ideas<br />To <span class="accent-blue">Reality</span></h1>
+			<h1 class="main-title">
+				Kickstart your Ideas<br />To <span class="accent-blue">Reality</span>
+			</h1>
 			<p>Polytoria simplifies your multiplayer game development. Easy to get started for beginners, and welcoming from advanced developers.</p>
 
-			<!-- MAIN BUTTONS-->
-			<div style="position: relative; z-index: 2000">
-				<div class="d-block w-100 mx-auto fw-bold mb-2" style="--bs-border-width: 2px; --bs-border-radius: 7px">
-					<a href="tutorials/getting-started/introduction" class="btn btn-light"><i class="bx bxs-star"></i> Get Started!</a>
-					<div style="width: 5px; display: inline-block"></div>
-					<a href="objects/game/Game" class="btn btn-outline-light"><i class="bx bxs-book"></i> Read the Docs</a>
-				</div>
-				<!--
-        coming soon: <a href="#" class="text-muted">Developer from other platforms?</a>
-        -->
+			<!-- MAIN BUTTONS -->
+			<div class="hero-buttons d-block w-100 mx-auto mb-2">
+				<a href="tutorials/getting-started/introduction" class="btn btn-light" aria-label="Get started with Polytoria">
+					<i class="bx bxs-star" aria-hidden="true"></i> Get Started!
+				</a>
+				<a href="objects/game/Game" class="btn btn-outline-light" aria-label="Read the Polytoria API documentation">
+					<i class="bx bxs-book" aria-hidden="true"></i> Read the Docs
+				</a>
 			</div>
 
-			<!-- POP-UP CREATOR IMAGE-->
-			<div
-				style='
-					background: linear-gradient(
-							to bottom,
-							rgba(0, 0, 0, 0),
-							var(--background)
-						),
-						url("images/popup-background.png");
-					width: 100%;
-					height: 400px;
-					background-repeat: no-repeat;
-					background-position: center;
-				'
-			></div>
+			<!-- POP-UP CREATOR IMAGE (decorative) -->
+			<div class="hero-popup-image" role="presentation" aria-hidden="true"></div>
 
-			<!-- SPACER -->
-			<div style="height: 50px"></div>
+			<div class="spacer-sm"></div>
 
 			<!-- FEATURES -->
-			<h3 class="mb-4">
+			<h2 class="mb-4">
 				Polytoria helps you kickstart your idea
 				<span class="accent-red">faster</span>
-			</h3>
+			</h2>
 			<div class="row w-75 mx-auto text-center">
 				<div class="col-md-4">
 					<div class="card h-100">
 						<div class="card-body">
-							<div
-								class="d-block mx-auto mt-3"
-								style="
-									width: 150px;
-									height: 150px;
-									border-radius: 10px;
-									background: #262626;
-								"
-							></div>
-							<br />
-							<h3 style="font-size: 25px">Simple 3d</h3>
-							<span class="text-muted"> Different from other engines, in Polytoria you can build using parts, it's a piece of cake! </span>
-							<div style="height: 10px"></div>
+							<h3 style="font-size: 25px">Simple 3D</h3>
+							<p class="text-muted">Different from other engines, in Polytoria you can build using parts — it's a piece of cake!</p>
 						</div>
 					</div>
 				</div>
 				<div class="col-md-4">
 					<div class="card h-100">
 						<div class="card-body">
-							<div
-								class="d-block mx-auto mt-3"
-								style="
-									width: 150px;
-									height: 150px;
-									border-radius: 10px;
-									background: #262626;
-								"
-							></div>
-							<br />
 							<h3 style="font-size: 25px">Simple Multiplayer</h3>
-							<span class="text-muted"> Multiplayer is already built in Polytoria, all you need to do is create your game! </span>
-							<div style="height: 10px"></div>
+							<p class="text-muted">Multiplayer is already built into Polytoria — all you need to do is create your game!</p>
 						</div>
 					</div>
 				</div>
 				<div class="col-md-4">
 					<div class="card h-100">
-						<div class="card-body mt-auto mb-auto">
-							<div
-								class="d-block mx-auto mt-3"
-								style="
-									width: 150px;
-									height: 150px;
-									border-radius: 10px;
-									background: #262626;
-								"
-							></div>
-							<br />
+						<div class="card-body">
 							<h3 style="font-size: 25px">Release to the Globe</h3>
-							<span class="text-muted"> Polytoria has a vibrant community, with players from all around the world! </span>
-							<div style="height: 10px"></div>
+							<p class="text-muted">Polytoria has a vibrant community, with players from all around the world!</p>
 						</div>
 					</div>
 				</div>
 			</div>
 
-			<!-- COMMUNITY CREATIONS (HIDDEN ON MOBILE) -->
-			<!-- TO-DO: maybe make this automatically fetch top games -->
+			<!-- COMMUNITY CREATIONS (hidden on mobile) -->
 			<div class="mobile-hidden">
-				<!-- SPACER -->
-				<div style="height: 50px"></div>
+				<div class="spacer-sm"></div>
 
-				<h3>Backed by a Global Developer Community</h3>
+				<h2>Backed by a Global Developer Community</h2>
 				<p class="text-muted">People from around the world come together and create their own places.</p>
+
 				<div class="row mb-4 justify-content-center">
 					<div class="col-auto">
-						<a href="https://polytoria.com/places/6010" target="_blank" class="text-decoration-none">
+						<a href="https://polytoria.com/places/6010" target="_blank" rel="noopener noreferrer" class="text-decoration-none" aria-label="Play Treasure Divers by InsertSoda on Polytoria">
 							<div
 								class="card game-card"
-								style='
-									background-image: url("https://cdn.polytoria.com/places/thumbnails/dbrWfrZGoFHB6pXF-1gEmj7ZuL_wSHLT.png");
-								'
+								style="background-image: url('https://cdn.polytoria.com/places/thumbnails/dbrWfrZGoFHB6pXF-1gEmj7ZuL_wSHLT.png');"
 							>
 								<div class="card-body">
 									<div class="game-card-details">
@@ -199,8 +170,11 @@
 											<div class="col-auto">
 												<img
 													src="https://cdn.polytoria.com/thumbnails/avatars/e6248af7ed19bf887b06d498123c360d8ccea1b7690ae975962646d1051be9ba-icon.png"
-													alt="InsertSoda's Avatar"
+													alt="InsertSoda's avatar"
 													class="avatar-headshot img-fluid"
+													width="40"
+													height="40"
+													loading="lazy"
 												/>
 											</div>
 											<div class="col" style="--bs-gutter-x: 0px">
@@ -214,12 +188,10 @@
 						</a>
 					</div>
 					<div class="col-auto">
-						<a href="https://polytoria.com/places/6012" target="_blank" class="text-decoration-none">
+						<a href="https://polytoria.com/places/6012" target="_blank" rel="noopener noreferrer" class="text-decoration-none" aria-label="Play Operation: Sea Cleanup by Index on Polytoria">
 							<div
 								class="card game-card"
-								style='
-									background-image: url("https://cdn.polytoria.com/places/thumbnails/79aA7oX_pVSPtsodL4p1QgHVhzm8Pg1A.png");
-								'
+								style="background-image: url('https://cdn.polytoria.com/places/thumbnails/79aA7oX_pVSPtsodL4p1QgHVhzm8Pg1A.png');"
 							>
 								<div class="card-body">
 									<div class="game-card-details">
@@ -227,8 +199,11 @@
 											<div class="col-auto">
 												<img
 													src="https://cdn.polytoria.com/thumbnails/avatars/266480133a3e239581e9e93d3060dcc33c5adc7dcad265fee541b5ede30d67e7-icon.png"
-													alt="Index's Avatar"
+													alt="Index's avatar"
 													class="avatar-headshot img-fluid"
+													width="40"
+													height="40"
+													loading="lazy"
 												/>
 											</div>
 											<div class="col" style="--bs-gutter-x: 0px">
@@ -242,14 +217,13 @@
 						</a>
 					</div>
 				</div>
+
 				<div class="row mb-2 justify-content-center">
 					<div class="col-auto">
-						<a href="https://polytoria.com/places/6456" target="_blank" class="text-decoration-none">
+						<a href="https://polytoria.com/places/6456" target="_blank" rel="noopener noreferrer" class="text-decoration-none" aria-label="Play Butterfly Yoinker by abplntxp on Polytoria">
 							<div
 								class="card game-card"
-								style='
-									background-image: url("https://cdn.polytoria.com/places/thumbnails/XImnomv8OntkWKrfjpXniJLi3Ta2Qxn8.png");
-								'
+								style="background-image: url('https://cdn.polytoria.com/places/thumbnails/XImnomv8OntkWKrfjpXniJLi3Ta2Qxn8.png');"
 							>
 								<div class="card-body">
 									<div class="game-card-details">
@@ -257,8 +231,11 @@
 											<div class="col-auto">
 												<img
 													src="https://cdn.polytoria.com/thumbnails/avatars/07c4596f04aaa9a61262809e07bc73853cd66809276ef7aa449e4c78fffb0574-icon.png"
-													alt="abplntxp's Avatar"
+													alt="abplntxp's avatar"
 													class="avatar-headshot img-fluid"
+													width="40"
+													height="40"
+													loading="lazy"
 												/>
 											</div>
 											<div class="col" style="--bs-gutter-x: 0px">
@@ -272,12 +249,10 @@
 						</a>
 					</div>
 					<div class="col-auto">
-						<a href="https://polytoria.com/places/6253" target="_blank" class="text-decoration-none">
+						<a href="https://polytoria.com/places/6253" target="_blank" rel="noopener noreferrer" class="text-decoration-none" aria-label="Play snal's island by turmoil on Polytoria">
 							<div
 								class="card game-card"
-								style='
-									background-image: url("https://cdn.polytoria.com/places/thumbnails/3G2kazyp8K9YGs7G_x_fnmdMcmmvRgJT.png");
-								'
+								style="background-image: url('https://cdn.polytoria.com/places/thumbnails/3G2kazyp8K9YGs7G_x_fnmdMcmmvRgJT.png');"
 							>
 								<div class="card-body">
 									<div class="game-card-details">
@@ -285,8 +260,11 @@
 											<div class="col-auto">
 												<img
 													src="https://cdn.polytoria.com/thumbnails/avatars/b9f70221214607413d1dcff6c4a917cc4f6755cadf02583b08172bb3eb24e6bf-icon.png"
-													alt="turmoil's Avatar"
+													alt="turmoil's avatar"
 													class="avatar-headshot img-fluid"
+													width="40"
+													height="40"
+													loading="lazy"
 												/>
 											</div>
 											<div class="col" style="--bs-gutter-x: 0px">
@@ -302,49 +280,48 @@
 				</div>
 			</div>
 
-			<!-- SPACER -->
-			<div style="height: 100px"></div>
+			<div class="spacer-md"></div>
 
 			<!-- DEVELOPER RESOURCES -->
-			<h3>Resources</h3>
+			<h2>Resources</h2>
 			<p class="text-muted">Interested in developing for Polytoria? The Polytoria Documentation gives you all the resources you need to get started on creating your game.</p>
 			<div class="row mb-5">
 				<div class="col-md-2"></div>
 				<div class="col-md-2">
-					<a href="objects/game/Game" class="text-decoration-none text-reset">
+					<a href="objects/game/Game" class="text-decoration-none text-reset" aria-label="Read the API Documentation">
 						<div class="card h-100 resource-link" style="border: 1px solid gray">
 							<div class="card-body">
-								<img src="images/icons/book.svg" class="img-fluid mt-3 mb-3" alt="API Documentation Icon" />
+								<img src="images/icons/book.svg" class="img-fluid mt-3 mb-3" alt="" aria-hidden="true" width="48" height="48" loading="lazy" />
 								<h3 class="text-truncate" style="font-size: 20px">API Documentation</h3>
 							</div>
 						</div>
 					</a>
 				</div>
 				<div class="col-md-2">
-					<a href="tutorials/basic-scripting/" class="text-decoration-none text-reset">
+					<a href="tutorials/basic-scripting/" class="text-decoration-none text-reset" aria-label="Browse Tutorials">
 						<div class="card h-100 resource-link" style="border: 1px solid gray">
 							<div class="card-body">
-								<img src="images/icons/glasses.svg" class="img-fluid mt-3 mb-3" alt="Tutorials Icon" />
+								<img src="images/icons/glasses.svg" class="img-fluid mt-3 mb-3" alt="" aria-hidden="true" width="48" height="48" loading="lazy" />
 								<h3 style="font-size: 20px">Tutorials</h3>
 							</div>
 						</div>
 					</a>
 				</div>
 				<div class="col-md-2">
-					<a href="tutorials/getting-started/" class="text-decoration-none text-reset">
+					<a href="tutorials/getting-started/" class="text-decoration-none text-reset" aria-label="View Demos">
 						<div class="card h-100 resource-link" style="border: 1px solid gray">
 							<div class="card-body">
-								<img src="images/icons/cube.svg" class="img-fluid mt-3 mb-3" alt="Demos Icon" />
+								<img src="images/icons/cube.svg" class="img-fluid mt-3 mb-3" alt="" aria-hidden="true" width="48" height="48" loading="lazy" />
 								<h3 style="font-size: 20px">Demos</h3>
 							</div>
 						</div>
 					</a>
 				</div>
 				<div class="col-md-2">
-					<a href="https://discord.gg/sqVSKZRpdB" class="text-decoration-none text-reset" target="_blank">
+					<a href="https://discord.gg/sqVSKZRpdB" class="text-decoration-none text-reset" target="_blank" rel="noopener noreferrer" aria-label="Join the DevHub Community on Discord (opens in new tab)">
 						<div class="card h-100 resource-link" style="border: 1px solid gray">
 							<div class="card-body">
-								<img src="images/icons/discord.svg" class="img-fluid mt-3 mb-3" alt="DevHub Community Icon" />
+								<img src="images/icons/discord.svg" class="img-fluid mt-3 mb-3" alt="" aria-hidden="true" width="48" height="48" loading="lazy" />
 								<h3 style="font-size: 20px">DevHub Community</h3>
 							</div>
 						</div>
@@ -353,67 +330,53 @@
 				<div class="col-md-2"></div>
 			</div>
 
-			<!-- DEVELOPER RESOURCES -->
-			<h3>Get Involved</h3>
+			<!-- GET INVOLVED -->
+			<h2>Get Involved</h2>
 			<p class="text-muted">Want to help get involved to help develop Polytoria together?</p>
 			<div class="row">
 				<div class="col-md-3"></div>
 				<div class="col">
-					<a href="https://github.com/Polytoria/Docs" class="text-decoration-none text-reset" target="_blank">
+					<a href="https://github.com/Polytoria/Docs" class="text-decoration-none text-reset" target="_blank" rel="noopener noreferrer" aria-label="Improve the Polytoria Docs on GitHub (opens in new tab)">
 						<div class="card h-100" style="border: 1px solid gray">
 							<div class="card-body">
-								<img src="images/icons/Github.svg" class="img-fluid mt-3 mb-3" alt="Improve the Docs Icon" />
+								<img src="images/icons/Github.svg" class="img-fluid mt-3 mb-3" alt="" aria-hidden="true" width="48" height="48" loading="lazy" />
 								<h3 style="font-size: 20px">Improve the Docs</h3>
 							</div>
 						</div>
 					</a>
 				</div>
-				<!--
-      <div class="col">
-        <a href="#" class="text-decoration-none text-reset" target="_blank">
-          <div class="card h-100" style="border: 1px solid gray;">
-            <div class="card-body">
-              <img src="images/icons/users.svg" class="img-fluid mt-3 mb-3" alt="Apply for Developer Icon">
-              <h3 style="font-size: 20px;">Apply for Developer</h3>
-            </div>
-          </div>
-        </a>
-      </div>
-      -->
 				<div class="col-md-3"></div>
 			</div>
 
-			<!-- SPACER -->
-			<div style="height: 100px"></div>
+			<div class="spacer-md"></div>
 
 			<!-- START YOUR JOURNEY -->
-			<div class="row w-100" style="padding: 5rem; position: relative">
-				<div
-					style='
-						background-image: url("images/start-journey.png");
-						background-size: cover;
-						width: 100%;
-						height: 100%;
-						position: absolute;
-						top: 0;
-						left: 0;
-					'
-				></div>
-				<div class="col" style="z-index: 1">
+			<div class="journey-section row w-100">
+				<div class="journey-bg" role="presentation" aria-hidden="true"></div>
+				<div class="col journey-content">
 					<h2 class="fw-bold start-journey-text" style="text-align: left">Start your journey today.</h2>
 				</div>
-				<div class="col-md-3" style="z-index: 1">
-					<a href="objects/game/Game" class="btn btn-light"><i class="bx bxs-star"></i> Get Started!</a>
+				<div class="col-md-3 journey-content">
+					<a href="objects/game/Game" class="btn btn-light" aria-label="Get started with Polytoria">
+						<i class="bx bxs-star" aria-hidden="true"></i> Get Started!
+					</a>
 				</div>
 			</div>
 
 			<!-- FOOTER -->
-			<div class="row text-muted p-4" style="padding-right: 200px !important; padding-left: 200px !important">
+			<footer class="row text-muted site-footer" aria-label="Site footer">
 				<div class="col" style="text-align: left">Polytoria &copy; 2019-2025</div>
 				<div class="col-md-3">
-					<img src="images/polytoria-gray.svg" alt="Polytoria Logo" />
+					<img src="images/polytoria-gray.svg" alt="Polytoria" width="120" height="24" loading="lazy" />
 				</div>
-			</div>
+			</footer>
+
 		</div>
+
+		<script
+			src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+			integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+			crossorigin="anonymous"
+		></script>
 	</body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,15 +1,24 @@
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500&family=Poppins:wght@400;500;700&display=swap');
 
+/* =============================================
+   VARIABLES
+   ============================================= */
 :root {
 	--background: #181818;
 	--polytoria-red: #dd5555;
 }
 
+/* =============================================
+   SCROLLBAR
+   ============================================= */
 ::-webkit-scrollbar {
 	width: 0px;
 	background: transparent;
 }
 
+/* =============================================
+   BASE
+   ============================================= */
 html,
 body {
 	background-color: var(--background) !important;
@@ -22,28 +31,210 @@ body {
 	overflow-x: hidden;
 }
 
-body {
-	font-family: Arial, sans-serif;
-	margin: 0;
-	padding: 0;
-	overflow: hidden;
+.text-center {
+	position: relative;
+	z-index: 1;
 }
 
-.container {
-	max-width: 1200px;
-	margin: 0 auto;
-	padding: 0 15px;
+/* =============================================
+   NAVBAR
+   ============================================= */
+.navbar {
+	--bs-navbar-brand-color: #fff !important;
+	--bs-navbar-brand-hover-color: #fff !important;
+}
+
+nav .navbar-brand {
+	font-family: 'JetBrains Mono', sans-serif;
+	font-weight: 500;
+}
+
+nav .nav-link {
+	color: #a1a3a4 !important;
+}
+
+.navbar-toggler-icon {
+	filter: brightness(100);
+}
+
+/* =============================================
+   CARDS
+   ============================================= */
+.card {
+	--bs-card-bg: #1f1f1f !important;
+	--bs-card-border-radius: 10px !important;
+}
+
+/* =============================================
+   TYPOGRAPHY
+   ============================================= */
+.main-title {
+	font-size: 60px;
+	font-weight: 700;
+}
+
+.accent-blue {
+	background: linear-gradient(180deg, #0097ff 26.11%, #804fe8 73.33%), linear-gradient(0deg, #ffffff, #ffffff);
+	background-clip: text;
+	-webkit-background-clip: text;
+	color: transparent;
+}
+
+.accent-red {
+	color: var(--polytoria-red);
+}
+
+/* =============================================
+   HERO — ICONS BACKGROUND
+   ============================================= */
+.hero-icons-bg {
+	background-image: url("images/icons-background.png");
+	background-color: transparent;
+	position: absolute;
+	margin-top: 4rem;
+	background-repeat: no-repeat;
+	background-position: top center;
+	width: 100%;
+	height: 450px;
+	pointer-events: none;
+}
+
+/* =============================================
+   HERO — POPUP IMAGE
+   ============================================= */
+.hero-popup-image {
+	background: linear-gradient(to bottom, rgba(0, 0, 0, 0), var(--background, #181818)),
+		url("images/popup-background.png");
+	background-color: var(--background);
+	width: 100%;
+	height: 400px;
+	background-repeat: no-repeat;
+	background-position: center;
+}
+
+/* =============================================
+   HERO — BUTTONS
+   ============================================= */
+.hero-buttons {
+	position: relative;
+	z-index: 2000;
+}
+
+.hero-buttons .btn {
+	font-weight: bold;
+	--bs-border-width: 2px;
+	--bs-border-radius: 7px;
+}
+
+.hero-buttons .btn + .btn {
+	margin-left: 5px;
+}
+
+/* =============================================
+   FEATURE CARDS — placeholder boxes
+   ============================================= */
+.feature-card-placeholder {
+	display: block;
+	width: 150px;
+	height: 150px;
+	border-radius: 10px;
+	background: #262626;
+	margin: 1rem auto 0;
+}
+
+/* =============================================
+   GAME / COMMUNITY CARDS
+   ============================================= */
+.avatar-headshot {
+	width: 70px;
+	height: 70px;
+	border-radius: 100%;
+}
+
+.game-card {
+	width: 500px;
+	height: 300px !important;
+	border-radius: 10px;
+	background-size: cover;
+}
+
+.game-card-details {
+	text-align: left;
+}
+
+.game-card-details p {
+	text-shadow: 0 3px 10px #00000040;
+	color: #e6e6e6;
+	font-size: 20px;
+	font-weight: 500;
+}
+
+.game-card-details span {
+	text-shadow: 0 3px 10px #00000040;
+	color: #e6e6e6;
+}
+
+.game-card .avatar-headshot {
+	background: #00000040;
+	box-shadow: 0 2px 10px 0px #00000040;
+}
+
+/* =============================================
+   START YOUR JOURNEY BANNER
+   ============================================= */
+.journey-section {
+	padding: 5rem;
+	position: relative;
+}
+
+.journey-bg {
+	background-image: url("images/start-journey.png");
+	background-color: #1a1a2e;
+	background-size: cover;
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	left: 0;
+}
+
+.journey-content {
+	position: relative;
+	z-index: 1;
+}
+
+/* =============================================
+   FOOTER
+   ============================================= */
+.site-footer {
+	padding: 1.5rem 12.5rem;
+}
+
+/* =============================================
+   SPACERS
+   ============================================= */
+.spacer-sm  { height: 50px;  }
+.spacer-md  { height: 100px; }
+.spacer-lg  { height: 125px; }
+
+/* =============================================
+   CONTRIBUTORS PAGE
+   ============================================= */
+@keyframes scroll {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+}
+
+.contributors-list {
+	display: inline-block;
+	white-space: nowrap;
+	animation: scroll 20s linear infinite;
 }
 
 .contributors {
 	overflow-x: auto;
 	white-space: nowrap;
 	padding: 20px 0;
-}
-
-.text-center {
-	position: relative;
-	z-index: 1;
 }
 
 .contributor {
@@ -120,6 +311,16 @@ body {
 	color: #cdcdcd;
 }
 
+/* =============================================
+   RESOURCE LINKS
+   ============================================= */
+.resource-link {
+	transition: border-color 0.2s ease;
+}
+
+/* =============================================
+   RESPONSIVE
+   ============================================= */
 @media only screen and (max-width: 850px) {
 	.mobile-hidden {
 		display: none;
@@ -142,79 +343,4 @@ body {
 	.col-md-2:has(.resource-link) {
 		margin-bottom: 20px;
 	}
-}
-
-.navbar {
-	--bs-navbar-brand-color: #fff !important;
-	--bs-navbar-brand-hover-color: #fff !important;
-}
-
-nav .navbar-brand {
-	font-family: 'JetBrains Mono', sans-serif;
-	font-weight: 500;
-}
-
-nav .nav-link {
-	color: #a1a3a4 !important;
-}
-
-.card {
-	--bs-card-bg: #1f1f1f !important;
-	--bs-card-border-radius: 10px !important;
-}
-
-.main-title {
-	font-size: 60px;
-	font-weight: 700;
-}
-
-.accent-blue {
-	background: linear-gradient(180deg, #0097ff 26.11%, #804fe8 73.33%), linear-gradient(0deg, #ffffff, #ffffff);
-	background-clip: text;
-	-webkit-background-clip: text;
-	color: transparent;
-}
-
-.accent-red {
-	color: var(--polytoria-red);
-}
-
-.avatar-headshot {
-	width: 70px;
-	height: 70px;
-	border-radius: 100%;
-}
-
-.game-card {
-	width: 500px;
-	height: 300px !important;
-	border-radius: 10px;
-
-	background-size: cover;
-}
-
-.game-card-details {
-	text-align: left;
-}
-
-.game-card-details p {
-	text-shadow: 0 3px 10px #00000040;
-	color: #e6e6e6;
-
-	font-size: 20px;
-	font-weight: 500;
-}
-
-.game-card-details span {
-	text-shadow: 0 3px 10px #00000040;
-	color: #e6e6e6;
-}
-
-.game-card .avatar-headshot {
-	background: #00000040;
-	box-shadow: 0 2px 10px 0px #00000040;
-}
-
-.navbar-toggler-icon {
-	filter: brightness(100);
 }

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -19,3 +19,13 @@
 {% block scripts %}
 	{{ super() }}
 {% endblock %}
+
+{% block header %}
+    <!-- Custom Banner -->
+    <div class="banner">
+        <p style="display:inline;font-size:0.8rem;">2.0 is coming! Learn more <a href="/whats-next.html" style="color: #007bff !important; text-decoration: underline !important;">here</a>.</p>
+    </div>
+
+    <!-- Original Header -->
+    {% include "partials/header.html" %}
+{% endblock %}

--- a/docs/whats-next.html
+++ b/docs/whats-next.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="index, follow" />
+		<meta name="author" content="Polytoria" />
+		<meta name="description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API." />
+		<link rel="canonical" href="https://docs.polytoria.com" />
+		<link rel="icon" href="images/favicon.ico" type="image/x-icon" />
+
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://docs.polytoria.com" />
+		<meta property="og:title" content="Polytoria Scripting API — Kickstart Your Ideas to Reality" />
+		<meta property="og:description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API. Easy for beginners, welcoming for advanced developers." />
+		<meta property="og:image" content="images/popup-background.png" />
+
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content="Polytoria Scripting API — Kickstart Your Ideas to Reality" />
+		<meta name="twitter:description" content="Learn how to kickstart your ideas to reality with Polytoria's Scripting API." />
+		<meta name="twitter:image" content="images/popup-background.png" />
+
+		<title>Polytoria Scripting Docs</title>
+
+		<link rel="stylesheet" href="style.css" type="text/css" />
+		<link rel="stylesheet" href="/assets/extra.css" type="text/css" />
+		<link
+			href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+			rel="stylesheet"
+			integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
+			crossorigin="anonymous"
+		/>
+		<link
+			href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css"
+			rel="stylesheet"
+			integrity="sha384-cTQGMqRSW1uONNQVzr1E0bSxQDSaFR0BjHMYRfXEBNZSGAQ1MhQFAJqUgWMORiA"
+			crossorigin="anonymous"
+		/>
+
+		<meta name="theme-color" content="#2094f3" />
+	</head>
+	<body>
+
+		<!-- ICONS BACKGROUND (decorative, hidden from assistive tech) -->
+		<div class="hero-icons-bg" role="presentation" aria-hidden="true"></div>
+
+		<div class="banner">
+			<p style="display:inline;">2.0 is coming! Learn more <a href="/whats-next.html" style="color: #007bff !important; text-decoration: underline !important;">here</a>.</p>
+		</div>
+
+		<!-- NAVBAR -->
+		<nav class="navbar navbar-expand-lg w-75 mx-auto" aria-label="Main navigation">
+			<div class="container-fluid">
+				<a class="navbar-brand" href="/" aria-label="Polytoria Docs home">
+					<img
+						src="images/polytoria-white.svg"
+						alt="Polytoria"
+						width="120"
+						height="24"
+						style="vertical-align: top; margin-top: 1px"
+					/>
+					/docs
+				</a>
+				<button
+					class="navbar-toggler"
+					type="button"
+					data-bs-toggle="collapse"
+					data-bs-target="#navbarContent"
+					aria-controls="navbarContent"
+					aria-expanded="false"
+					aria-label="Toggle navigation"
+				>
+					<span class="navbar-toggler-icon"></span>
+				</button>
+				<div class="collapse navbar-collapse" id="navbarContent">
+					<ul class="navbar-nav me-auto mb-2 mb-lg-0">
+						<li class="nav-item">
+							<a class="nav-link" href="objects/game/Game/">API</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="tutorials/basic-scripting/about-scripting">Tutorials</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="tutorials/getting-started/introduction">Demos</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="contributors">Contributors</a>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</nav>
+
+		<div class="spacer-lg"></div>
+
+		<div class="text-center w-100">
+
+			<!-- TITLE -->
+			<h1 class="main-title">
+				Reimagine your ideas with <br />To <span class="accent-blue">Polytoria 2.0</span>
+			</h1>
+			<p>Polytoria's legacy client and creator and being rewritten from the ground up in a new game engine.<br />Learn what that means for you.</p>
+
+			<!-- POP-UP CREATOR IMAGE (decorative) -->
+			<div class="hero-popup-image" role="presentation" aria-hidden="true"></div>
+
+			<div class="spacer-sm"></div>
+
+			<!-- FEATURES -->
+			<h2 class="mb-4">
+				Polytoria 2.0 helps you kickstart your idea
+				<span class="accent-red">faster</span>
+			</h2>
+			<div class="row w-75 mx-auto text-center">
+				<div class="col-md-4">
+					<div class="card h-100">
+						<div class="card-body">
+							<h3 style="font-size: 25px">Rewritten from the ground up</h3>
+							<p class="text-muted">The new client and creator are rewritten in Godot, rather than Unity. Better performance and reliability - for all platforms.</p>
+						</div>
+					</div>
+				</div>
+				<div class="col-md-4">
+					<div class="card h-100">
+						<div class="card-body">
+							<h3 style="font-size: 25px">Simple Programming</h3>
+							<p class="text-muted">Instead of having to rely on Moonsharp Lua, like in the current application, Polytoria 2.0 allows you to script using LuaU!</p>
+						</div>
+					</div>
+				</div>
+				<div class="col-md-4">
+					<div class="card h-100">
+						<div class="card-body">
+							<h3 style="font-size: 25px">Open Source</h3>
+							<p class="text-muted">Polytoria 2.0 is open-sourced, for all to see and experiment with!</p>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="spacer-sm"></div>
+
+			<!-- DEVELOPER RESOURCES -->
+			<h2>Resources</h2>
+			<p class="text-muted">Interested in keeping up with 2.0? Check out the latest progress report on our blog.</p>
+			<div class="row mb-5">
+				<div class="col-md-2"></div>
+				<div class="col">
+					<a href="https://blog.polytoria.com/polytoria-2-0-progress-report-1/" target="_blank" class="text-decoration-none text-reset" aria-label="Read the latest progress report.">
+						<div class="card h-100 resource-link" style="border: 1px solid gray">
+							<div class="card-body">
+								<img src="images/icons/book.svg" class="img-fluid mt-3 mb-3" alt="" aria-hidden="true" width="48" height="48" loading="lazy" />
+								<h3 class="text-truncate" style="font-size: 20px">Progress Report #1</h3>
+							</div>
+						</div>
+					</a>
+				</div>
+				<div class="col">
+					<a href="https://blog.polytoria.com/polytoria-goes-open-source/" target="_blank" class="text-decoration-none text-reset" aria-label="Read the open-source announcement.">
+						<div class="card h-100 resource-link" style="border: 1px solid gray">
+							<div class="card-body">
+								<img src="images/icons/glasses.svg" class="img-fluid mt-3 mb-3" alt="" aria-hidden="true" width="48" height="48" loading="lazy" />
+								<h3 style="font-size: 20px">2.0 goes open source!</h3>
+							</div>
+						</div>
+					</a>
+				</div>
+				<div class="col-md-2"></div>
+			</div>
+
+			<div class="spacer-md"></div>
+
+			<!-- START YOUR JOURNEY -->
+			<div class="journey-section row w-100">
+				<div class="journey-bg" role="presentation" aria-hidden="true"></div>
+				<div class="col journey-content">
+					<h2 class="fw-bold start-journey-text" style="text-align: left">Start your journey today.</h2>
+				</div>
+				<div class="col-md-3 journey-content">
+					<a href="objects/game/Game" class="btn btn-light" aria-label="Get started with Polytoria">
+						<i class="bx bxs-star" aria-hidden="true"></i> Get Started!
+					</a>
+				</div>
+			</div>
+
+			<!-- FOOTER -->
+			<footer class="row text-muted site-footer" aria-label="Site footer">
+				<div class="col" style="text-align: left">Polytoria &copy; 2019-2025</div>
+				<div class="col-md-3">
+					<img src="images/polytoria-gray.svg" alt="Polytoria" width="120" height="24" loading="lazy" />
+				</div>
+			</footer>
+
+		</div>
+
+		<script
+			src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+			integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+			crossorigin="anonymous"
+		></script>
+	</body>
+</html>


### PR DESCRIPTION
## clean up homepage & add "2.0 is coming" banner

- the homepage has been cleaned up, removed placeholder icons, fixed some CSS, improved accessibility w/ little visible change

- "2.0" is coming banner & page shown below. if this is not wanted, it can be removed. figured it'd be good to alert users of the documentation site. not sure if it's too earlier

2.0 is coming banner:
<img width="1594" height="524" alt="image" src="https://github.com/user-attachments/assets/5501f8e3-84b5-41f0-ae8e-a6338ac93c0f" />

2.0 is coming page:
<img width="1722" height="1064" alt="image" src="https://github.com/user-attachments/assets/d1163c87-3016-45df-ad4d-34982fceeb7d" />
<img width="1702" height="300" alt="image" src="https://github.com/user-attachments/assets/d41a9d34-c3a9-4fc1-8ed2-fe7c810a7fa8" />
